### PR TITLE
Feat : event 등록 및 alarm, event group 생성 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,6 @@ dependencies {
 	// firebase auth
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,11 @@
 plugins {
 	id("org.springframework.boot") version "3.3.1"
 	id("io.spring.dependency-management") version "1.1.5"
-	id("org.jetbrains.kotlin.plugin.allopen") version "1.8.0"
+//	id("org.jetbrains.kotlin.plugin.allopen") version "1.8.0"
 	kotlin("plugin.jpa") version "1.9.24"
 	kotlin("jvm") version "1.9.24"
 	kotlin("plugin.spring") version "1.9.24"
+	kotlin("plugin.allopen") version "1.8.0"
 }
 
 group = "com.dnight"
@@ -21,8 +22,9 @@ repositories {
 }
 
 allOpen {
-	annotation("javax.persistence.Entity")
-	annotation("javax.persistence.MappedSuperclass")
+	annotation("jakarta.persistence.Entity")
+	annotation("jakarta.persistence.MappedSuperclass")
+	annotation("jakarta.persistence.Embeddable")
 	annotation("org.springframework.stereotype.Component")
 	annotation("org.springframework.stereotype.Service")
 	annotation("org.springframework.web.bind.annotation.RestController")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("org.springframework.boot") version "3.3.1"
 	id("io.spring.dependency-management") version "1.1.5"
+	id("org.jetbrains.kotlin.plugin.allopen") version "1.8.0"
 	kotlin("plugin.jpa") version "1.9.24"
 	kotlin("jvm") version "1.9.24"
 	kotlin("plugin.spring") version "1.9.24"
@@ -19,12 +20,23 @@ repositories {
 	mavenCentral()
 }
 
+allOpen {
+	annotation("javax.persistence.Entity")
+	annotation("javax.persistence.MappedSuperclass")
+	annotation("org.springframework.stereotype.Component")
+	annotation("org.springframework.stereotype.Service")
+	annotation("org.springframework.web.bind.annotation.RestController")
+}
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+	testImplementation("io.projectreactor:reactor-test")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 //	developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 	runtimeOnly("com.mysql:mysql-connector-j")
@@ -33,10 +45,15 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	//WebClient
+	runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.1")
+
 	// firebase auth
-	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-	implementation("org.springframework.boot:spring-boot-starter-security")
-	testImplementation("org.springframework.security:spring-security-test")
+//	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+//	implementation("org.springframework.boot:spring-boot-starter-security")
+//	testImplementation("org.springframework.security:spring-security-test")
 }
 
 kotlin {

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
@@ -1,0 +1,25 @@
+package com.dnight.calinify.ai_process.controller
+
+import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.response.ProcessedEventResponseDTO
+import com.dnight.calinify.ai_process.service.EventProcessingService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/eventProcessing")
+class EventProcessingController(
+    private val eventProcessingService: EventProcessingService
+) {
+    @PostMapping("/plainText")
+    fun creatPlainTextEvent(@RequestBody plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : ProcessedEventResponseDTO {
+
+        val processedEventResponse = eventProcessingService.createPlainTextEvent(plainTextProcessingRequestDTO)
+
+        return processedEventResponse
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
@@ -3,8 +3,6 @@ package com.dnight.calinify.ai_process.controller
 import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.response.ProcessedEventResponseDTO
 import com.dnight.calinify.ai_process.service.EventProcessingService
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/PlainTextProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/PlainTextProcessingRequestDTO.kt
@@ -1,0 +1,18 @@
+package com.dnight.calinify.ai_process.dto.request
+
+import com.dnight.calinify.ai_process.dto.to_ai.request.AiRequestDTO
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+
+data class PlainTextProcessingRequestDTO(
+    @field:Min(1)
+    val promptId : Int = 1,
+
+    @field:NotEmpty
+    @field:Size(max = 2047)
+    val originText: String,
+
+    @field:Min(1)
+    val inputType : Int,
+)

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/PlainTextProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/PlainTextProcessingRequestDTO.kt
@@ -1,11 +1,10 @@
 package com.dnight.calinify.ai_process.dto.request
 
-import com.dnight.calinify.ai_process.dto.to_ai.request.AiRequestDTO
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 
-data class PlainTextProcessingRequestDTO(
+class PlainTextProcessingRequestDTO(
     @field:Min(1)
     val promptId : Int = 1,
 

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
@@ -6,8 +6,8 @@ import java.time.LocalDateTime
 class ProcessedEventResponseDTO(
     val processedEventId : Long,
     val summary : String,
-    val start : LocalDateTime,
-    val end : LocalDateTime,
+    val startAt : LocalDateTime,
+    val endAt : LocalDateTime,
     val responseTime : Float,
     val usedToken : Int,
     val location : String?,
@@ -20,8 +20,8 @@ class ProcessedEventResponseDTO(
             return ProcessedEventResponseDTO(
                 processedEventId = processedEventId,
                 summary = processedResponseBody.summary,
-                start = processedResponseBody.start!!,
-                end = processedResponseBody.end!!,
+                startAt = processedResponseBody.start!!,
+                endAt = processedResponseBody.end!!,
                 responseTime = processedResponseBody.responseTime,
                 usedToken = processedResponseBody.usedToken,
                 location = processedResponseBody.location,

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
@@ -3,7 +3,7 @@ package com.dnight.calinify.ai_process.dto.response
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
 import java.time.LocalDateTime
 
-data class ProcessedEventResponseDTO(
+class ProcessedEventResponseDTO(
     val processedEventId : Long,
     val summary : String,
     val start : LocalDateTime,

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
@@ -1,0 +1,34 @@
+package com.dnight.calinify.ai_process.dto.response
+
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import java.time.LocalDateTime
+
+data class ProcessedEventResponseDTO(
+    val processedEventId : Long,
+    val summary : String,
+    val start : LocalDateTime,
+    val end : LocalDateTime,
+    val responseTime : Float,
+    val usedToken : Int,
+    val location : String?,
+    val description : String?,
+    val priority : Short? = 5,
+    val repeatRule : String?,
+) {
+    companion object {
+        fun from(processedEventId: Long, processedResponseBody : AiPlainTextProcessedResponseDTO) : ProcessedEventResponseDTO {
+            return ProcessedEventResponseDTO(
+                processedEventId = processedEventId,
+                summary = processedResponseBody.summary,
+                start = processedResponseBody.start!!,
+                end = processedResponseBody.end!!,
+                responseTime = processedResponseBody.responseTime,
+                usedToken = processedResponseBody.usedToken,
+                location = processedResponseBody.location,
+                description = processedResponseBody.description,
+                priority = processedResponseBody.priority,
+                repeatRule = processedResponseBody.repeatRule,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
@@ -2,12 +2,12 @@ package com.dnight.calinify.ai_process.dto.to_ai.request
 
 import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
 
-data class AiPlainTextProcessingRequestDTO(
+class AiPlainTextProcessingRequestDTO(
     override val promptId : Int,
     val plainText : String
 ) : AiRequestDTO() {
     companion object {
-        fun from(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : AiPlainTextProcessingRequestDTO {
+        fun toEntity(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : AiPlainTextProcessingRequestDTO {
             return AiPlainTextProcessingRequestDTO(
                 plainTextProcessingRequestDTO.promptId,
                 plainTextProcessingRequestDTO.originText

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
@@ -1,0 +1,17 @@
+package com.dnight.calinify.ai_process.dto.to_ai.request
+
+import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
+
+data class AiPlainTextProcessingRequestDTO(
+    override val promptId : Int,
+    val plainText : String
+) : AiRequestDTO() {
+    companion object {
+        fun from(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : AiPlainTextProcessingRequestDTO {
+            return AiPlainTextProcessingRequestDTO(
+                plainTextProcessingRequestDTO.promptId,
+                plainTextProcessingRequestDTO.originText
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiRequestDTO.kt
@@ -1,0 +1,5 @@
+package com.dnight.calinify.ai_process.dto.to_ai.request
+
+abstract class AiRequestDTO {
+    abstract val promptId: Int
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
@@ -1,0 +1,15 @@
+package com.dnight.calinify.ai_process.dto.to_ai.response
+
+import java.time.LocalDateTime
+
+data class AiPlainTextProcessedResponseDTO(
+    val summary : String,
+    val start : LocalDateTime?,
+    val end : LocalDateTime?,
+    val responseTime : Float,
+    val usedToken : Int,
+    val location : String?,
+    val description : String?,
+    val priority : Short? = 5,
+    val repeatRule : String?,
+) : AiResponseDTO()

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
@@ -1,8 +1,12 @@
 package com.dnight.calinify.ai_process.dto.to_ai.response
 
+import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.user.entity.UserEntity
 import java.time.LocalDateTime
 
-data class AiPlainTextProcessedResponseDTO(
+class AiPlainTextProcessedResponseDTO(
     val summary : String,
     val start : LocalDateTime?,
     val end : LocalDateTime?,
@@ -12,4 +16,34 @@ data class AiPlainTextProcessedResponseDTO(
     val description : String?,
     val priority : Short? = 5,
     val repeatRule : String?,
-) : AiResponseDTO()
+) : AiResponseDTO() {
+
+    companion object {
+        fun toStatisticsEntity(userEntity : UserEntity,
+                     aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO,
+                     inputData: PlainTextProcessingRequestDTO): AiProcessingStatisticsEntity {
+            return AiProcessingStatisticsEntity(
+                user = userEntity,
+                inputOriginText = inputData.originText,
+                promptId = inputData.promptId,
+                inputType = inputData.inputType,
+                responseTime = aiPlainTextProcessedResponseDTO.responseTime,
+                usedToken = aiPlainTextProcessedResponseDTO.usedToken,
+            )
+        }
+
+        fun toEventEntity(eventProcessedStatisticsId : Long,
+                 aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO
+        ) : AiProcessingEventEntity {
+            return AiProcessingEventEntity(
+                aiProcessingEventId = eventProcessedStatisticsId,
+                summary = aiPlainTextProcessedResponseDTO.summary,
+                startAt = aiPlainTextProcessedResponseDTO.start!!,
+                endAt = aiPlainTextProcessedResponseDTO.end!!,
+                description = aiPlainTextProcessedResponseDTO.description,
+                location = aiPlainTextProcessedResponseDTO.location,
+                repeatRule = aiPlainTextProcessedResponseDTO.repeatRule,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiResponseDTO.kt
@@ -1,0 +1,3 @@
+package com.dnight.calinify.ai_process.dto.to_ai.response
+
+open class AiResponseDTO

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "ai_processing_event")
-data class AiProcessingEventEntity(
+class AiProcessingEventEntity(
 
     @Id
     val aiProcessingEventId : Long? = 0,
@@ -31,20 +31,4 @@ data class AiProcessingEventEntity(
 
     @Column(nullable = true, length = 255)
     val repeatRule : String? = null
-) {
-    companion object {
-        fun from(eventProcessedStatisticsId : Long,
-                 aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO
-        ) : AiProcessingEventEntity {
-            return AiProcessingEventEntity(
-                aiProcessingEventId = eventProcessedStatisticsId,
-                summary = aiPlainTextProcessedResponseDTO.summary,
-                startAt = aiPlainTextProcessedResponseDTO.start!!,
-                endAt = aiPlainTextProcessedResponseDTO.end!!,
-                description = aiPlainTextProcessedResponseDTO.description,
-                location = aiPlainTextProcessedResponseDTO.location,
-                repeatRule = aiPlainTextProcessedResponseDTO.repeatRule,
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.ai_process.entity
 
-import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingEventEntity.kt
@@ -1,0 +1,50 @@
+package com.dnight.calinify.ai_process.entity
+
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "ai_processing_event")
+data class AiProcessingEventEntity(
+
+    @Id
+    val aiProcessingEventId : Long? = 0,
+
+    @Column(nullable = false, length = 50)
+    val summary : String,
+
+    @Column(nullable = false)
+    val startAt : LocalDateTime,
+
+    @Column(nullable = false)
+    val endAt : LocalDateTime,
+
+    @Column(nullable = true, length = 2047)
+    val description : String? = null,
+
+    @Column(nullable = true, length = 255)
+    val location : String? = null,
+
+    @Column(nullable = true, length = 255)
+    val repeatRule : String? = null
+) {
+    companion object {
+        fun from(eventProcessedStatisticsId : Long,
+                 aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO
+        ) : AiProcessingEventEntity {
+            return AiProcessingEventEntity(
+                aiProcessingEventId = eventProcessedStatisticsId,
+                summary = aiPlainTextProcessedResponseDTO.summary,
+                startAt = aiPlainTextProcessedResponseDTO.start!!,
+                endAt = aiPlainTextProcessedResponseDTO.end!!,
+                description = aiPlainTextProcessedResponseDTO.description,
+                location = aiPlainTextProcessedResponseDTO.location,
+                repeatRule = aiPlainTextProcessedResponseDTO.repeatRule,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingStatisticsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingStatisticsEntity.kt
@@ -1,0 +1,63 @@
+package com.dnight.calinify.ai_process.entity
+
+import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.user.entity.UserEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "ai_processing_statistics")
+data class AiProcessingStatisticsEntity(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val aiProcessingStatisticsId: Long? = 0,
+
+    @OneToOne
+    @JoinColumn(name = "ai_processing_statistics_id")
+    val aiProcessingEvent : AiProcessingEventEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: UserEntity,
+
+    @Column(nullable = false, length = 2047)
+    val inputOriginText : String,
+
+    @Column(nullable = false)
+    val inputType: Int,
+
+    @Column(nullable = false)
+    val promptId : Int,
+
+    @Column(nullable = false)
+    val responseTime : Float,
+
+    @Column(nullable = false)
+    val usedToken : Int,
+
+    // 성공을 기본값으로 잡는다.
+    @Column(nullable = false)
+    var isSuccess : Short = 1,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = true)
+    var eventId: EventEntity? = null
+) {
+    fun addEventId(eventId: EventEntity) {
+        this.eventId = eventId
+    }
+
+    companion object {
+        fun from(userEntity : UserEntity, aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO, inputData: PlainTextProcessingRequestDTO): AiProcessingStatisticsEntity {
+            return AiProcessingStatisticsEntity(
+                user = userEntity,
+                inputOriginText = inputData.originText,
+                promptId = inputData.promptId,
+                inputType = inputData.inputType,
+                responseTime = aiPlainTextProcessedResponseDTO.responseTime,
+                usedToken = aiPlainTextProcessedResponseDTO.usedToken,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingStatisticsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/entity/AiProcessingStatisticsEntity.kt
@@ -1,14 +1,11 @@
 package com.dnight.calinify.ai_process.entity
 
-import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
-import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
-import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.*
 
 @Entity
 @Table(name = "ai_processing_statistics")
-data class AiProcessingStatisticsEntity(
+class AiProcessingStatisticsEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val aiProcessingStatisticsId: Long? = 0,
@@ -39,25 +36,4 @@ data class AiProcessingStatisticsEntity(
     // 성공을 기본값으로 잡는다.
     @Column(nullable = false)
     var isSuccess : Short = 1,
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id", nullable = true)
-    var eventId: EventEntity? = null
-) {
-    fun addEventId(eventId: EventEntity) {
-        this.eventId = eventId
-    }
-
-    companion object {
-        fun from(userEntity : UserEntity, aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO, inputData: PlainTextProcessingRequestDTO): AiProcessingStatisticsEntity {
-            return AiProcessingStatisticsEntity(
-                user = userEntity,
-                inputOriginText = inputData.originText,
-                promptId = inputData.promptId,
-                inputType = inputData.inputType,
-                responseTime = aiPlainTextProcessedResponseDTO.responseTime,
-                usedToken = aiPlainTextProcessedResponseDTO.usedToken,
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/module/WebClientConfig.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/module/WebClientConfig.kt
@@ -1,0 +1,34 @@
+package com.dnight.calinify.ai_process.module
+
+import io.netty.channel.ChannelOption
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ClientHttpConnector
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
+
+@Configuration
+class WebClientConfig {
+    /**
+     * ai server(FastAPI)와 통신하는 webClient
+     *
+     * 15초를 기준으로 타임아웃을 설정한다.
+     *
+     * base url은 ai 서버의 도메인을 넣는다.
+     *
+     * @author 정인모
+     */
+
+    @Bean
+    fun aiRequestBuilder(): WebClient.Builder {
+        val httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 15000)
+            .responseTimeout(Duration.ofMillis(15000))
+        return WebClient.builder()
+            .baseUrl("http://localhost:5050")
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .defaultHeader("Content-Type", "application/json")
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/repository/AiProcessingEventRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/repository/AiProcessingEventRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.ai_process.repository
+
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AiProcessingEventRepository : JpaRepository<AiProcessingEventEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/repository/AiProcessingStatisticsRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/repository/AiProcessingStatisticsRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.ai_process.repository
+
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AiProcessingStatisticsRepository : JpaRepository<AiProcessingStatisticsEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
@@ -6,8 +6,6 @@ import com.dnight.calinify.ai_process.dto.to_ai.request.AiPlainTextProcessingReq
 import com.dnight.calinify.ai_process.dto.to_ai.request.AiRequestDTO
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
-import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
-import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
 import com.dnight.calinify.ai_process.repository.AiProcessingEventRepository
 import com.dnight.calinify.ai_process.repository.AiProcessingStatisticsRepository
 import com.dnight.calinify.config.basicResponse.ResponseCode
@@ -61,7 +59,7 @@ class EventProcessingService(
     fun createPlainTextEvent(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : ProcessedEventResponseDTO{
 
         // DTO로부터 ai server에 전달할 내용을 정제
-        val aiPlainTextProcessingRequestDTO = AiPlainTextProcessingRequestDTO.from(plainTextProcessingRequestDTO)
+        val aiPlainTextProcessingRequestDTO = AiPlainTextProcessingRequestDTO.toEntity(plainTextProcessingRequestDTO)
 
         // ai server request
         val aiPlainTextProcessedResponseDTO = aiRequest(aiPlainTextProcessingRequestDTO, AiPlainTextProcessedResponseDTO::class)
@@ -74,7 +72,7 @@ class EventProcessingService(
         val userEntity = userRepository.findByIdOrNull(1) ?: throw ClientException(ResponseCode.UserNotFound)
 
         // 통계 객체 생성
-        val eventProcessedStatisticsEntity = AiProcessingStatisticsEntity.from(userEntity, processedResponseBody, plainTextProcessingRequestDTO)
+        val eventProcessedStatisticsEntity = AiPlainTextProcessedResponseDTO.toStatisticsEntity(userEntity, processedResponseBody, plainTextProcessingRequestDTO)
 
         // 일정 정보 파악 실패 시 예외 발생
         if (aiPlainTextProcessedResponseDTO.statusCode.isSameCodeAs(HttpStatus.ACCEPTED)) {
@@ -88,7 +86,7 @@ class EventProcessingService(
         val eventProcessingId : Long = eventStatisticsEntity.aiProcessingStatisticsId!!
 
         // 성공했을 시, processing event 삽입 (실제 유저 event 반영 x)
-        val processingEventEntity = AiProcessingEventEntity.from(eventProcessingId, processedResponseBody)
+        val processingEventEntity = AiPlainTextProcessedResponseDTO.toEventEntity(eventProcessingId, processedResponseBody)
         aiProcessingEventRepository.save(processingEventEntity)
 
         // 프로세싱 결과에 statistics, event id를 삽입하여 반환

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
@@ -1,0 +1,100 @@
+package com.dnight.calinify.ai_process.service
+
+import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.response.ProcessedEventResponseDTO
+import com.dnight.calinify.ai_process.dto.to_ai.request.AiPlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.to_ai.request.AiRequestDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.ai_process.repository.AiProcessingEventRepository
+import com.dnight.calinify.ai_process.repository.AiProcessingStatisticsRepository
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.config.exception.DontRollbackException
+import com.dnight.calinify.config.exception.ServerSideException
+import com.dnight.calinify.user.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import reactor.core.publisher.Mono
+import java.net.ConnectException
+import kotlin.reflect.KClass
+
+@Service
+class EventProcessingService(
+    private val aiProcessingEventRepository: AiProcessingEventRepository,
+    private val aiProcessingStatisticsRepository: AiProcessingStatisticsRepository,
+    private val userRepository: UserRepository,
+    aiRequestBuilder: WebClient.Builder
+) {
+    private val aiRequestClient = aiRequestBuilder.build()
+
+    fun <T : AiResponseDTO> aiRequest(requestDTO : AiRequestDTO, responseCls : KClass<T>) : ResponseEntity<T>? {
+        return aiRequestClient.post()
+            .uri("/api/v1/plainText")
+            .bodyValue(requestDTO)
+            .retrieve()
+            .toEntity(responseCls.java)
+            .onErrorResume { ex ->
+                when (ex) {
+                    is WebClientRequestException -> {
+                        Mono.error(ServerSideException(ResponseCode.AiRequestFail))
+                    }
+                    is ConnectException -> {
+                        Mono.error(ServerSideException(ResponseCode.AiRequestFail))
+                    }
+                    else -> {
+                        Mono.error(RuntimeException("알 수 없는 오류 발생: ${ex.message}"))
+                    }
+                }
+            }
+            .block()
+    }
+
+    @Transactional(dontRollbackOn = [DontRollbackException::class])
+    fun createPlainTextEvent(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : ProcessedEventResponseDTO{
+
+        // DTO로부터 ai server에 전달할 내용을 정제
+        val aiPlainTextProcessingRequestDTO = AiPlainTextProcessingRequestDTO.from(plainTextProcessingRequestDTO)
+
+        // ai server request
+        val aiPlainTextProcessedResponseDTO = aiRequest(aiPlainTextProcessingRequestDTO, AiPlainTextProcessedResponseDTO::class)
+            ?: throw ServerSideException(ResponseCode.AiRequestFail)
+
+        // 응답으로부터 body 추출
+        val processedResponseBody = aiPlainTextProcessedResponseDTO.body!!
+
+        // TODO User 정보는 더미 데이터, 토큰에서 유저 값 갖고 오기
+        val userEntity = userRepository.findByIdOrNull(1) ?: throw ClientException(ResponseCode.UserNotFound)
+
+        // 통계 객체 생성
+        val eventProcessedStatisticsEntity = AiProcessingStatisticsEntity.from(userEntity, processedResponseBody, plainTextProcessingRequestDTO)
+
+        // 일정 정보 파악 실패 시 예외 발생
+        if (aiPlainTextProcessedResponseDTO.statusCode.isSameCodeAs(HttpStatus.ACCEPTED)) {
+            eventProcessedStatisticsEntity.isSuccess = 0
+            aiProcessingStatisticsRepository.save(eventProcessedStatisticsEntity)
+            throw DontRollbackException(ResponseCode.EventDataNotCaptured)
+        }
+
+        // 통계 정보 저장 및 ID 할당
+        val eventStatisticsEntity = aiProcessingStatisticsRepository.save(eventProcessedStatisticsEntity)
+        val eventProcessingId : Long = eventStatisticsEntity.aiProcessingStatisticsId!!
+
+        // 성공했을 시, processing event 삽입 (실제 유저 event 반영 x)
+        val processingEventEntity = AiProcessingEventEntity.from(eventProcessingId, processedResponseBody)
+        aiProcessingEventRepository.save(processingEventEntity)
+
+        // 프로세싱 결과에 statistics, event id를 삽입하여 반환
+        val processedEventResponseDTO = ProcessedEventResponseDTO.from(
+            eventProcessingId, processedResponseBody)
+
+        return processedEventResponseDTO
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/alarm/controller/AlarmController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/controller/AlarmController.kt
@@ -1,0 +1,47 @@
+package com.dnight.calinify.alarm.controller
+
+import com.dnight.calinify.alarm.dto.request.AlarmCreateRequestDTO
+import com.dnight.calinify.alarm.dto.request.AlarmUpdateRequestDTO
+import com.dnight.calinify.alarm.dto.response.AlarmResponseDTO
+import com.dnight.calinify.alarm.service.AlarmService
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import jakarta.validation.Valid
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/alarm")
+@Validated
+class AlarmController(
+    private val alarmService: AlarmService
+) {
+    // TODO User를 추가해 권한을 관리할 필요가 있다...
+    @GetMapping("/{alarmId}")
+    fun getAlarmById(@PathVariable alarmId : Long) : BasicResponse<AlarmResponseDTO>{
+        val alarm = alarmService.getAlarmById(alarmId)
+
+        return BasicResponse.ok(alarm, ResponseCode.ResponseSuccess)
+    }
+
+    @PostMapping("/")
+    fun createAlarm(@Valid @RequestBody alarmCreateRequestDTO: AlarmCreateRequestDTO) : BasicResponse<AlarmResponseDTO>{
+        val alarm = alarmService.createAlarm(alarmCreateRequestDTO)
+
+        return BasicResponse.ok(alarm, ResponseCode.CreateSuccess)
+    }
+
+    @PutMapping("/")
+    fun updateAlarm(@RequestBody alarmUpdateRequestDTO: AlarmUpdateRequestDTO) : BasicResponse<AlarmResponseDTO>{
+        val alarm = alarmService.updateAlarm(alarmUpdateRequestDTO)
+
+        return BasicResponse.ok(alarm, ResponseCode.UpdateSuccess)
+    }
+
+    @DeleteMapping("/{alarmId}")
+    fun deleteAlarmById(@PathVariable alarmId : Long) : BasicResponse<Map<String, Long>>{
+        val deletedAlarmMap = alarmService.deleteAlarmById(alarmId)
+
+        return BasicResponse.ok(deletedAlarmMap, ResponseCode.DeleteSuccess)
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/alarm/controller/AlarmController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/controller/AlarmController.kt
@@ -25,10 +25,10 @@ class AlarmController(
     }
 
     @PostMapping("/")
-    fun createAlarm(@Valid @RequestBody alarmCreateRequestDTO: AlarmCreateRequestDTO) : BasicResponse<AlarmResponseDTO>{
-        val alarm = alarmService.createAlarm(alarmCreateRequestDTO)
+    fun createAlarm(@Valid @RequestBody alarmCreateRequestDTO: AlarmCreateRequestDTO) : BasicResponse<Long>{
+        val alarmId = alarmService.createAlarm(alarmCreateRequestDTO)
 
-        return BasicResponse.ok(alarm, ResponseCode.CreateSuccess)
+        return BasicResponse.ok(alarmId, ResponseCode.CreateSuccess)
     }
 
     @PutMapping("/")

--- a/src/main/kotlin/com/Dnight/calinify/alarm/dto/request/AlarmCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/dto/request/AlarmCreateRequestDTO.kt
@@ -1,0 +1,32 @@
+package com.dnight.calinify.alarm.dto.request
+
+import com.dnight.calinify.alarm.entity.AlarmAction
+import com.dnight.calinify.alarm.entity.AlarmEntity
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.validation.constraints.Size
+
+class AlarmCreateRequestDTO(
+    @field:Enumerated(EnumType.STRING)
+    @Schema(description = "알람의 방식", defaultValue = "DISPLAY")
+    val alarmAction: AlarmAction = AlarmAction.DISPLAY,
+
+    @field:Size(max = 255)
+    @Schema(description = "알람이 울릴 시간, 방식은 정해봐야할 것 같음", defaultValue = "B:15;")
+    val alarmTrigger: String = "B15;",
+
+    @field:Size(max = 50)
+    @Schema(description = "알람과 함께 표시할 텍스트")
+    val description : String,
+) {
+    companion object {
+        fun toEntity(alarmCreateRequestDTO: AlarmCreateRequestDTO): AlarmEntity {
+            return AlarmEntity(
+                alarmTrigger = alarmCreateRequestDTO.alarmTrigger,
+                description = alarmCreateRequestDTO.description,
+                action = alarmCreateRequestDTO.alarmAction
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/alarm/dto/request/AlarmUpdateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/dto/request/AlarmUpdateRequestDTO.kt
@@ -1,0 +1,21 @@
+package com.dnight.calinify.alarm.dto.request
+
+import com.dnight.calinify.alarm.entity.AlarmAction
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+
+class AlarmUpdateRequestDTO(
+    @field:Min(1)
+    val alarmId: Long,
+
+    @field:Enumerated(EnumType.STRING)
+    val alarmAction: AlarmAction,
+
+    @field:Size(max = 255)
+    val alarmTrigger: String,
+
+    @field:Size(max = 50)
+    val description : String,
+)

--- a/src/main/kotlin/com/Dnight/calinify/alarm/dto/response/AlarmResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/dto/response/AlarmResponseDTO.kt
@@ -1,0 +1,25 @@
+package com.dnight.calinify.alarm.dto.response
+
+import com.dnight.calinify.alarm.entity.AlarmAction
+import com.dnight.calinify.alarm.entity.AlarmEntity
+
+class AlarmResponseDTO(
+    val alarmId: Long,
+
+    val action: AlarmAction,
+
+    val alarmTrigger: String,
+
+    val description: String,
+) {
+    companion object {
+        fun from(alarmEntity: AlarmEntity) : AlarmResponseDTO {
+            return AlarmResponseDTO(
+                alarmId = alarmEntity.alarmId!!,
+                action = alarmEntity.action,
+                alarmTrigger = alarmEntity.alarmTrigger,
+                description = alarmEntity.description,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/alarm/entity/AlarmAction.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/entity/AlarmAction.kt
@@ -1,0 +1,7 @@
+package com.dnight.calinify.alarm.entity
+
+enum class AlarmAction {
+    AUDIO,
+    DISPLAY,
+    EMAIL;
+}

--- a/src/main/kotlin/com/Dnight/calinify/alarm/entity/AlarmEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/entity/AlarmEntity.kt
@@ -1,0 +1,20 @@
+package com.dnight.calinify.alarm.entity
+
+import com.dnight.calinify.config.basicEntity.BasicEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "alarm")
+class AlarmEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val alarmId: Long? = 0,
+
+    @Enumerated(EnumType.STRING)
+    var action: AlarmAction = AlarmAction.DISPLAY,
+
+    @Column(nullable = false)
+    var alarmTrigger: String = "B15;",
+
+    @Column(nullable = false)
+    var description: String,
+): BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/alarm/repository/AlarmRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/repository/AlarmRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.alarm.repository
+
+import com.dnight.calinify.alarm.entity.AlarmEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AlarmRepository : JpaRepository<AlarmEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/alarm/service/AlarmService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/service/AlarmService.kt
@@ -22,12 +22,12 @@ class AlarmService(
     }
 
     @Transactional
-    fun createAlarm(alarmCreateRequestDTO: AlarmCreateRequestDTO) : AlarmResponseDTO {
+    fun createAlarm(alarmCreateRequestDTO: AlarmCreateRequestDTO) : Long {
         val alarmEntity = AlarmCreateRequestDTO.toEntity(alarmCreateRequestDTO)
 
         val createdAlarm = alarmRepository.save(alarmEntity)
 
-        return AlarmResponseDTO.from(createdAlarm)
+        return createdAlarm.alarmId!!
     }
 
     @Transactional

--- a/src/main/kotlin/com/Dnight/calinify/alarm/service/AlarmService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/alarm/service/AlarmService.kt
@@ -1,0 +1,52 @@
+package com.dnight.calinify.alarm.service
+
+import com.dnight.calinify.alarm.dto.request.AlarmCreateRequestDTO
+import com.dnight.calinify.alarm.dto.request.AlarmUpdateRequestDTO
+import com.dnight.calinify.alarm.dto.response.AlarmResponseDTO
+import com.dnight.calinify.alarm.repository.AlarmRepository
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class AlarmService(
+    private val alarmRepository: AlarmRepository,
+) {
+    fun getAlarmById(alarmId : Long) : AlarmResponseDTO {
+
+        val alarmEntity = alarmRepository.findByIdOrNull(alarmId) ?: throw ClientException(ResponseCode.NotFound)
+
+        return AlarmResponseDTO.from(alarmEntity)
+    }
+
+    @Transactional
+    fun createAlarm(alarmCreateRequestDTO: AlarmCreateRequestDTO) : AlarmResponseDTO {
+        val alarmEntity = AlarmCreateRequestDTO.toEntity(alarmCreateRequestDTO)
+
+        val createdAlarm = alarmRepository.save(alarmEntity)
+
+        return AlarmResponseDTO.from(createdAlarm)
+    }
+
+    @Transactional
+    fun updateAlarm(alarmUpdateRequestDTO: AlarmUpdateRequestDTO) : AlarmResponseDTO {
+        val alarmEntity = alarmRepository.findByIdOrNull(alarmUpdateRequestDTO.alarmId) ?: throw ClientException(ResponseCode.NotFound)
+
+        alarmEntity.alarmTrigger = alarmUpdateRequestDTO.alarmTrigger
+        alarmEntity.action = alarmUpdateRequestDTO.alarmAction
+        alarmEntity.description = alarmUpdateRequestDTO.description
+
+        return AlarmResponseDTO.from(alarmEntity)
+    }
+
+    @Transactional
+    fun deleteAlarmById(alarmId : Long) : Map<String, Long> {
+        alarmRepository.deleteById(alarmId)
+
+        val deletedAlarmId = mapOf("deleted alarm id" to alarmId)
+
+        return deletedAlarmId
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/SecurityConfig.kt
@@ -1,28 +1,28 @@
 package com.dnight.calinify.auth
 
-import jakarta.servlet.DispatcherType
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpMethod
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.web.DefaultSecurityFilterChain
-import org.springframework.security.web.SecurityFilterChain
-
-@EnableWebSecurity
-@Configuration
-class SecurityConfig {
-
-    @Bean
-    fun securityFilterChain(http: HttpSecurity): DefaultSecurityFilterChain? {
-        http
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/v3/**", "/swagger-ui/**").permitAll()
-                    .anyRequest().authenticated()
-            }
-            // resource server 활성화
-            .oauth2ResourceServer { oauth -> oauth.jwt { } }
-        return http.build()
-    }
-}
+//import jakarta.servlet.DispatcherType
+//import org.springframework.context.annotation.Bean
+//import org.springframework.context.annotation.Configuration
+//import org.springframework.http.HttpMethod
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+//import org.springframework.security.web.DefaultSecurityFilterChain
+//import org.springframework.security.web.SecurityFilterChain
+//
+//@EnableWebSecurity
+//@Configuration
+//class SecurityConfig {
+//
+//    @Bean
+//    fun securityFilterChain(http: HttpSecurity): DefaultSecurityFilterChain? {
+//        http
+//            .authorizeHttpRequests { auth ->
+//                auth
+//                    .requestMatchers("/v3/**", "/swagger-ui/**").permitAll()
+//                    .anyRequest().authenticated()
+//            }
+//            // resource server 활성화
+//            .oauth2ResourceServer { oauth -> oauth.jwt { } }
+//        return http.build()
+//    }
+//}

--- a/src/main/kotlin/com/Dnight/calinify/auth/SwaggerConfig.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/SwaggerConfig.kt
@@ -1,34 +1,34 @@
 package com.Dnight.calinify.auth
 
-import io.swagger.v3.oas.models.Components
-import io.swagger.v3.oas.models.OpenAPI
-import io.swagger.v3.oas.models.security.SecurityRequirement
-import io.swagger.v3.oas.models.security.SecurityScheme
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-
-@Configuration
-class SwaggerConfig {
-    @Bean
-    fun customizeOpenAPI(): OpenAPI {
-        return OpenAPI()
-            .addSecurityItem(
-                SecurityRequirement()
-                    .addList(SwaggerConfig.Companion.OAUTH_SCHEME_BEARER)
-            )
-            .components(
-                Components()
-                    .addSecuritySchemes(
-                        SwaggerConfig.Companion.OAUTH_SCHEME_BEARER, SecurityScheme()
-                            .name(SwaggerConfig.Companion.OAUTH_SCHEME_BEARER)
-                            .type(SecurityScheme.Type.HTTP)
-                            .scheme("bearer")
-                            .bearerFormat("JWT")
-                    )
-            )
-    }
-
-    companion object {
-        private const val OAUTH_SCHEME_BEARER = "bearerAuth"
-    }
-}
+//import io.swagger.v3.oas.models.Components
+//import io.swagger.v3.oas.models.OpenAPI
+//import io.swagger.v3.oas.models.security.SecurityRequirement
+//import io.swagger.v3.oas.models.security.SecurityScheme
+//import org.springframework.context.annotation.Bean
+//import org.springframework.context.annotation.Configuration
+//
+//@Configuration
+//class SwaggerConfig {
+//    @Bean
+//    fun customizeOpenAPI(): OpenAPI {
+//        return OpenAPI()
+//            .addSecurityItem(
+//                SecurityRequirement()
+//                    .addList(SwaggerConfig.Companion.OAUTH_SCHEME_BEARER)
+//            )
+//            .components(
+//                Components()
+//                    .addSecuritySchemes(
+//                        SwaggerConfig.Companion.OAUTH_SCHEME_BEARER, SecurityScheme()
+//                            .name(SwaggerConfig.Companion.OAUTH_SCHEME_BEARER)
+//                            .type(SecurityScheme.Type.HTTP)
+//                            .scheme("bearer")
+//                            .bearerFormat("JWT")
+//                    )
+//            )
+//    }
+//
+//    companion object {
+//        private const val OAUTH_SCHEME_BEARER = "bearerAuth"
+//    }
+//}

--- a/src/main/kotlin/com/Dnight/calinify/auth/controller.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/controller.kt
@@ -1,20 +1,20 @@
 package com.dnight.calinify.auth;
 
-import org.springframework.security.core.Authentication
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-
-@RestController
-@RequestMapping(value = ["/auth"])
-public class controller {
-    @GetMapping(value = ["/uid"])
-    fun uid(authentication: Authentication): String {
-        return authentication.name
-    }
-
-    @GetMapping(value = ["/hello"])
-    fun hello(): String {
-        return "hello world"
-    }
-}
+//import org.springframework.security.core.Authentication
+//import org.springframework.web.bind.annotation.GetMapping
+//import org.springframework.web.bind.annotation.RequestMapping
+//import org.springframework.web.bind.annotation.RestController
+//
+//@RestController
+//@RequestMapping(value = ["/auth"])
+//public class controller {
+//    @GetMapping(value = ["/uid"])
+//    fun uid(authentication: Authentication): String {
+//        return authentication.name
+//    }
+//
+//    @GetMapping(value = ["/hello"])
+//    fun hello(): String {
+//        return "hello world"
+//    }
+//}

--- a/src/main/kotlin/com/Dnight/calinify/calendar/dto/request/CalendarCreateDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/dto/request/CalendarCreateDTO.kt
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
-data class CalendarCreateDTO(
+class CalendarCreateDTO(
 
     @field:Min(1)
     val userId : Long,

--- a/src/main/kotlin/com/Dnight/calinify/calendar/dto/request/CalendarUpdateDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/dto/request/CalendarUpdateDTO.kt
@@ -21,7 +21,7 @@ data class CalendarUpdateDTO(
 
     val timezoneId : String = "Asia/Seoul",
 
-    var colorSetId : Int,
+    val colorSetId : Int,
 
     var deleted : Short
 )

--- a/src/main/kotlin/com/Dnight/calinify/calendar/dto/response/CalendarResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/dto/response/CalendarResponseDTO.kt
@@ -3,7 +3,7 @@ package com.dnight.calinify.calendar.dto.response
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import java.time.LocalDateTime
 
-data class CalendarResponseDTO(
+class CalendarResponseDTO(
     val calendarId : Long,
     val title : String,
     val timezoneId : String,

--- a/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
@@ -6,8 +6,7 @@ import jakarta.persistence.*
 
 @Entity
 @Table(name = "calendars")
-data class CalendarEntity(
-
+open class CalendarEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val calendarId : Long = 0,
 

--- a/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
@@ -27,4 +27,5 @@ class CalendarEntity(
 
     @Column(nullable = false)
     var deleted : Short = 0,
-) : BasicEntity()
+) : BasicEntity(){
+}

--- a/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/entity/CalendarEntity.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.*
 
 @Entity
 @Table(name = "calendars")
-open class CalendarEntity(
+class CalendarEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val calendarId : Long = 0,
 

--- a/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
@@ -3,4 +3,5 @@ package com.dnight.calinify.calendar.repository
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CalendarRepository : JpaRepository<CalendarEntity, Long>
+interface CalendarRepository : JpaRepository<CalendarEntity, Long> {
+}

--- a/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
@@ -20,9 +20,11 @@ class CalendarService(private val calendarRepository: CalendarRepository,
         val calendar : CalendarEntity = calendarRepository.findByIdOrNull(calendarId) ?: throw ClientException(
             ResponseCode.NotFound)
 
+        val cUser = calendar.user
+
         // TODO 유저의 calendar 소유권한 확인 추가
 
-        if (calendar.equals(1)) throw ClientException(ResponseCode.DeletedResource)
+        if (calendar.deleted.toInt() == 1) throw ClientException(ResponseCode.DeletedResource)
 
         val calendarResponse = CalendarResponseDTO.from(calendar)
 

--- a/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
@@ -1,10 +1,10 @@
 package com.dnight.calinify.calendar.service
 
-import com.dnight.calinify.calendar.entity.CalendarEntity
-import com.dnight.calinify.calendar.repository.CalendarRepository
 import com.dnight.calinify.calendar.dto.request.CalendarCreateDTO
 import com.dnight.calinify.calendar.dto.request.CalendarUpdateDTO
 import com.dnight.calinify.calendar.dto.response.CalendarResponseDTO
+import com.dnight.calinify.calendar.entity.CalendarEntity
+import com.dnight.calinify.calendar.repository.CalendarRepository
 import com.dnight.calinify.config.basicResponse.ResponseCode
 import com.dnight.calinify.config.exception.ClientException
 import com.dnight.calinify.user.repository.UserRepository
@@ -13,14 +13,15 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
-class CalendarService(private val calendarRepository: CalendarRepository,
-    private val userRepository: UserRepository) {
-
+class CalendarService(
+    private val calendarRepository: CalendarRepository,
+    private val userRepository: UserRepository
+) {
+    @Transactional
     fun getCalendarById(calendarId : Long) : CalendarResponseDTO {
-        val calendar : CalendarEntity = calendarRepository.findByIdOrNull(calendarId) ?: throw ClientException(
-            ResponseCode.NotFound)
 
-        val cUser = calendar.user
+        val calendar : CalendarEntity = calendarRepository.findByIdOrNull(calendarId)
+            ?: throw ClientException(ResponseCode.NotFound)
 
         // TODO 유저의 calendar 소유권한 확인 추가
 

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsEntity.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 data class ColorSetsEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val colorSetId : Long = 0,
+    val colorSetId : Int = 0,
 
     @Column(nullable = false, length = 20)
     val colorName : String,

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsRepository.kt
@@ -2,4 +2,4 @@ package com.dnight.calinify.common.colorSets
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ColorSetsRepository : JpaRepository<ColorSetsEntity, Long>
+interface ColorSetsRepository : JpaRepository<ColorSetsEntity, Int>

--- a/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.config.basicEntity
 
-import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate

--- a/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
@@ -1,12 +1,18 @@
 package com.dnight.calinify.config.basicEntity
 
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
-open class BasicEntity {
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BasicEntity {
     @CreatedDate
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    var createdAt: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
     var updatedAt: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicEntity/BasicEntity.kt
@@ -9,5 +9,5 @@ open class BasicEntity {
     val createdAt: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
-    val updatedAt: LocalDateTime = LocalDateTime.now()
+    var updatedAt: LocalDateTime = LocalDateTime.now()
 }

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ExceptionResponse.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ExceptionResponse.kt
@@ -3,12 +3,10 @@ package com.dnight.calinify.config.basicResponse
 /**
  * 비즈니스 로직에서 캐치 가능한 예외에 대해, `BasicResponse<ExceptionResponse>`와 같은 형식으로 반환하기 위한 wrapper 클래스
  *
- *
- *
  * message는 ResponseCode마다 함께 선언된 예외 메시지가 자동으로 삽입된다.
  */
 class ExceptionResponse(
-    val message: String
+    val message: String,
 )
 
 class FailedValidationResponse<T>(

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
@@ -51,8 +51,9 @@ enum class ResponseCode(val statusCode: Int, val message: String) {
 
     InputDataNotValid(422, "입력한 데이터의 포맷이 맞지 않음"),
 
-    DuplicatedInputData(422, "중복된 데이터");
+    DuplicatedInputData(422, "중복된 데이터"),
 
     // 500 - 서버 에러
+    DataSaveFailed(500, "데이터 저장 실패")
     ;
 }

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
@@ -17,7 +17,7 @@ package com.dnight.calinify.config.basicResponse
  *
  * @author 정인모
  */
-enum class ResponseCode(val statusCode: Int, val message: String) {
+enum class ResponseCode(val statusCode: Int, var message: String) {
 
     // 200 - 요청 처리 성공
 

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
@@ -49,11 +49,15 @@ enum class ResponseCode(val statusCode: Int, val message: String) {
 
     LargeText(413, "입력한 데이터의 길이가 너무 긺"),
 
+    EventDataNotCaptured(422, "이벤트 데이터 포착 실패"),
+
     InputDataNotValid(422, "입력한 데이터의 포맷이 맞지 않음"),
 
     DuplicatedInputData(422, "중복된 데이터"),
 
     // 500 - 서버 에러
-    DataSaveFailed(500, "데이터 저장 실패")
+    DataSaveFailed(500, "데이터 저장 실패"),
+
+    AiRequestFail(500, "Ai 서버와 통신 실패")
     ;
 }

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/ClientException.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/ClientException.kt
@@ -4,4 +4,5 @@ import com.dnight.calinify.config.basicResponse.ResponseCode
 
 class ClientException(
     val responseCode: ResponseCode,
+    val detail : String? = null,
 ) : RuntimeException()

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/DontRollbackException.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/DontRollbackException.kt
@@ -2,6 +2,6 @@ package com.dnight.calinify.config.exception
 
 import com.dnight.calinify.config.basicResponse.ResponseCode
 
-class ClientException(
+class DontRollbackException (
     val responseCode: ResponseCode,
 ) : RuntimeException()

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
@@ -45,24 +45,16 @@ class GlobalExceptionHandler {
     }
 
     /**
-     * Unique 제약으로 인해, 데이터를 입력할 수 없는 경우 발생하는 에러
+     * DB에 걸린 Unique, Fk 등의 제약사항으로 인해 sql query 실행에서 예외가 발생한 경우
      *
-     * DB 쿼리 단에서 발생하는 예외이므로, 해당 메시지가 발생했다는 것은 `서비스 단에서 exception처리가 제대로 이루어지지 않았음`을 의미함.
-     *
-     * 당연히 DB의 값과 비교해야 하므로, db에 query가 날아가고, 반환된 query가 에러메시지에 담기므로 exception의 메시지를 반환시킬 수 없다.
-     *
-     * 코드의 기본 메시지 반환한다.
-     *
-     * 다만, unique 제약이 걸린 곳은 한정적이므로, 잘 찾아가면 된다.
-     *
-     * 가능하면 Client exception에서 `ResponseCode.DuplicatedInputData`로 반환될 수 있도록 만들자.
+     * 서비스 로직을 철저히 짜는 것으로, 해당 예외가 발생하는 것을 최소화하자.
      *
      * @author 정인모
      */
     @ExceptionHandler(DataIntegrityViolationException::class)
     fun handleDataIntegrityViolationException(ex: DataIntegrityViolationException): BasicResponse<ExceptionResponse> {
 
-        return BasicResponse.fail(ResponseCode.DuplicatedInputData)
+        return BasicResponse.fail(ResponseCode.DataSaveFailed)
     }
 
     /**

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
@@ -65,13 +65,15 @@ class GlobalExceptionHandler {
      *
      * 대부분의 비즈니스 로직에서 클라이언트에서 잘못된 값이 들어오거나 값 검증이 실패할 경우 발생할 예외
      *
+     * clientException에 detail String을 추가할 경우, 해당 string을 message에 추가해 반환
+     *
      * @author 정인모
      */
     @ExceptionHandler(ClientException::class)
     fun handleClientException(ex: ClientException): BasicResponse<ExceptionResponse> {
-        if (ex.detail == null) {
-            return BasicResponse.fail(ex.responseCode)
-        }
+        ex.detail ?:
+        return BasicResponse.fail(ex.responseCode)
+
         ex.responseCode.message += "->" + ex.detail
         return BasicResponse.fail(ex.responseCode)
     }

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
@@ -63,14 +63,16 @@ class GlobalExceptionHandler {
     /**
      * client(사용자 및 프론트엔드 단)측의 잘못으로 처리된 예외
      *
-     * 사용 예시:
-     *
-     * 추가 요망
+     * 대부분의 비즈니스 로직에서 클라이언트에서 잘못된 값이 들어오거나 값 검증이 실패할 경우 발생할 예외
      *
      * @author 정인모
      */
     @ExceptionHandler(ClientException::class)
     fun handleClientException(ex: ClientException): BasicResponse<ExceptionResponse> {
+        if (ex.detail == null) {
+            return BasicResponse.fail(ex.responseCode)
+        }
+        ex.responseCode.message += "->" + ex.detail
         return BasicResponse.fail(ex.responseCode)
     }
 

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,9 @@
 package com.dnight.calinify.config.exception
 
-import com.dnight.calinify.config.basicResponse.*
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ExceptionResponse
+import com.dnight.calinify.config.basicResponse.FailedValidationResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
@@ -83,6 +86,21 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(ServerSideException::class)
     fun handleServerSideException(ex: ServerSideException): BasicResponse<ExceptionResponse> {
+        return BasicResponse.fail(ex.responseCode)
+    }
+
+
+    /**
+     * 특수한 작업을 위해, 예외가 발생해도 트랜잭션을 완료하게 만들기 위한 예외
+     *
+     * 사용 예시 :
+     *
+     * 1. ai의 일정데이터 포착 실패로 422 예외를 반환해야 하지만, 실패 로그를 쌓기 위한 경우
+     *
+     * @author 정인모
+     */
+    @ExceptionHandler(DontRollbackException::class)
+    fun handleDontRollbackException(ex: DontRollbackException): BasicResponse<ExceptionResponse> {
         return BasicResponse.fail(ex.responseCode)
     }
 }

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/ServerSideException.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/ServerSideException.kt
@@ -4,5 +4,4 @@ import com.dnight.calinify.config.basicResponse.ResponseCode
 
 class ServerSideException(
     val responseCode: ResponseCode,
-    override val message: String = responseCode.message
 ) : RuntimeException()

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
@@ -25,9 +25,4 @@ class EventController(
 
         return BasicResponse.ok(eventCreateResponse, ResponseCode.CreateSuccess)
     }
-
-    @PostMapping("/plainText")
-    fun createPlainTextEvent(@RequestBody eventCreateDTO: PlainTextEventCreateRequestDTO){
-
-    }
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
@@ -5,12 +5,7 @@ import com.dnight.calinify.config.basicResponse.ResponseCode
 import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
 import com.dnight.calinify.event.dto.response.EventResponseDTO
 import com.dnight.calinify.event.service.EventService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("api/v1/event")
@@ -29,5 +24,10 @@ class EventController(
         val eventCreateResponse : EventResponseDTO = eventService.createEvent(eventCreateDTO)
 
         return BasicResponse.ok(eventCreateResponse, ResponseCode.CreateSuccess)
+    }
+
+    @PostMapping("/plainText")
+    fun createPlainTextEvent(@RequestBody eventCreateDTO: PlainTextEventCreateRequestDTO){
+
     }
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
@@ -1,0 +1,33 @@
+package com.dnight.calinify.event.controller
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
+import com.dnight.calinify.event.dto.response.EventResponseDTO
+import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.service.EventService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/v1/event")
+class EventController(
+    val eventService: EventService
+) {
+    @GetMapping("/{eventId}")
+    fun getEvent(@PathVariable eventId: Long) : BasicResponse<EventResponseDTO> {
+        val eventResponse : EventResponseDTO = eventService.getEventById(eventId)
+
+        return BasicResponse.ok(eventResponse, ResponseCode.ResponseSuccess)
+    }
+
+    @PostMapping("/")
+    fun createEvent(@RequestBody eventCreateDTO : EventCreateRequestDTO) {
+        val eventCreateResponse : EventResponseDTO = eventService.createEvent(eventCreateDTO)
+
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventController.kt
@@ -4,7 +4,6 @@ import com.dnight.calinify.config.basicResponse.BasicResponse
 import com.dnight.calinify.config.basicResponse.ResponseCode
 import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
 import com.dnight.calinify.event.dto.response.EventResponseDTO
-import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.service.EventService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -25,9 +24,10 @@ class EventController(
         return BasicResponse.ok(eventResponse, ResponseCode.ResponseSuccess)
     }
 
-    @PostMapping("/")
-    fun createEvent(@RequestBody eventCreateDTO : EventCreateRequestDTO) {
+    @PostMapping("/form")
+    fun createFormEvent(@RequestBody eventCreateDTO : EventCreateRequestDTO) : BasicResponse<EventResponseDTO> {
         val eventCreateResponse : EventResponseDTO = eventService.createEvent(eventCreateDTO)
 
+        return BasicResponse.ok(eventCreateResponse, ResponseCode.CreateSuccess)
     }
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/EventHistoryDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/EventHistoryDTO.kt
@@ -1,0 +1,24 @@
+package com.dnight.calinify.event.dto
+
+import com.dnight.calinify.event.dto.response.EventResponseDTO
+import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.entity.EventHistoryEntity
+
+class EventHistoryDTO() {
+    companion object {
+        fun toEntity(eventData : EventResponseDTO, event: EventEntity): EventHistoryEntity {
+            return EventHistoryEntity(
+                event = event,
+                summary = eventData.summary,
+                startAt = eventData.startAt,
+                endAt = eventData.endAt,
+                description = eventData.description,
+                priority = eventData.priority,
+                status = eventData.status,
+                transp = eventData.transp,
+                repeatRule = eventData.repeatRule,
+                location = eventData.location,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/EventStatisticsDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/EventStatisticsDTO.kt
@@ -1,0 +1,17 @@
+package com.dnight.calinify.event.dto
+
+import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
+import com.dnight.calinify.event.entity.EventStatisticsEntity
+
+class EventStatisticsDTO {
+    companion object{
+        fun toEntity(eventMeta : EventCreateRequestDTO,
+                     eventId : Long) : EventStatisticsEntity {
+            return EventStatisticsEntity(
+                eventStatisticsId = eventId,
+                inputTypeId = eventMeta.inputTypeId,
+                inputTimeTaken = eventMeta.inputTimeTaken,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -1,5 +1,6 @@
 package com.dnight.calinify.event.dto.request
 
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.entity.EventStatus
@@ -13,7 +14,7 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
-data class EventCreateRequestDTO(
+open class EventCreateRequestDTO(
     @field:NotEmpty
     val summary: String,
 
@@ -50,9 +51,15 @@ data class EventCreateRequestDTO(
     @Enumerated(EnumType.STRING)
     val transp : EventTransp,
 
-    val alarmId : Long? = null
+    val alarmId : Long? = null,
+
+    @field:Min(1)
+    val aiProcessingStatisticsId : Long? = null,
 ) {
     companion object {
+        /**
+         * aiProcessingStatisticsId가 존재하지 않는, Form으로 생성된 이벤트의 Entity를 만드는 메서드
+         */
         fun toEntity(eventData : EventCreateRequestDTO,
                      calendar : CalendarEntity) : EventEntity {
             return EventEntity(
@@ -69,7 +76,35 @@ data class EventCreateRequestDTO(
                 colorSetId = eventData.colorSetId,
                 status = eventData.status,
                 transp = eventData.transp,
-                alarm = eventData.alarmId
+                alarm = eventData.alarmId,
+            )
+        }
+
+        /**
+         * ai processing을 거쳐, aiProcessingStatisticsId를 함께 던져준 상태에서 적용.
+         *
+         * statistics 객체를 넣느냐 마느냐가 ai 답변인지 가르는 분기 플래그가 됨.
+         */
+
+        fun toEntity(eventData : EventCreateRequestDTO,
+                     calendar : CalendarEntity,
+                     aiProcessingStatisticsEntity: AiProcessingStatisticsEntity) : EventEntity {
+            return EventEntity(
+                uid = EventUID.genUID(),
+                summary = eventData.summary,
+                description = eventData.description,
+                startAt = eventData.startAt,
+                endAt = eventData.endAt,
+                priority = eventData.priority,
+                location = eventData.location,
+                repeatRule = eventData.repeatRule,
+                calendar = calendar,
+                eventGroupId = eventData.eventGroupId,
+                colorSetId = eventData.colorSetId,
+                status = eventData.status,
+                transp = eventData.transp,
+                alarm = eventData.alarmId,
+                aiProcessingStatistics = aiProcessingStatisticsEntity
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -1,94 +1,89 @@
 package com.dnight.calinify.event.dto.request
 
 import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.alarm.dto.request.AlarmCreateRequestDTO
+import com.dnight.calinify.alarm.entity.AlarmEntity
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.entity.EventStatus
 import com.dnight.calinify.event.entity.EventTransp
 import com.dnight.calinify.event.entity.EventUID
+import com.dnight.calinify.event_group.entity.EventGroupEntity
 import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
+import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDateTime
 
-open class EventCreateRequestDTO(
+class EventCreateRequestDTO(
     @field:NotEmpty
+    @Schema(description = "일정의 제목, 요약", defaultValue = "저녁 식사")
     val summary: String,
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "일정 시작 시간")
     val startAt: LocalDateTime,
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "일정 종료 시간")
     val endAt: LocalDateTime,
 
     @field:Size(max = 2047)
+    @Schema(description = "일정에 대한 부가 설명")
     val description : String?,
 
     @field:Size(min = 1, max= 9)
+    @Schema(description = "일정의 중요도. 1-9이며 입력이 없으면 기본값 5", defaultValue = "5")
     val priority : Short = 5,
 
     @field:Size(max = 255)
+    @Schema(description = "일정의 장소")
     val location : String? = null,
 
     @field:Size(max = 255)
+    @Schema(description = "반복 조건, 별도의 표현식 참조")
     val repeatRule : String? = null,
 
+    @Schema(description = "일정의 상태", defaultValue = "TENTATIVE")
+    val status : EventStatus = EventStatus.TENTATIVE,
+
+    @Schema(description = "일정의 투명도(시간의 중복 가능성)", defaultValue = "OPAQUE" )
+    val transp : EventTransp = EventTransp.OPAQUE,
+
     @field:Min(1)
+    @Schema(description = "일정이 입력될 캘린더 ID", defaultValue = "1")
     val calendarId: Long,
 
-    @field:Min(1)
-    val eventGroupId : Long,
-
-    @field:Min(1)
+    @Schema(description = "일정의 컬러셋, 생략 가능", defaultValue = "1")
     val colorSetId : Int? = null,
 
-    @Enumerated(EnumType.STRING)
-    val status : EventStatus,
+    @Schema(description = "일정 그룹의 ID, 생략 가능")
+    val eventGroupId : Long? = null,
 
-    @Enumerated(EnumType.STRING)
-    val transp : EventTransp,
+    @Schema(description = "일정에 등록할 알람, 일정 생성 시 함께 생성")
+    val alarm : AlarmCreateRequestDTO? = null,
 
-    val alarmId : Long? = null,
+    @Schema(description = "Ai Processing을 거친 일정일 경우 필수 포함. 순수 form 입력 시 공란")
+    val processedEventId : Long? = null,
 
+    @Schema(description = "사용자가 사용한 input 방식, 1:Form, 2:PlainText")
     @field:Min(1)
-    val aiProcessingStatisticsId : Long? = null,
+    val inputTypeId: Short,
+
+    @field:Min(0)
+    @Schema(description = "사용자가 일정을 등록하는 데에 활용한 종합 시간. 클라이언트에서 집계 후 전송")
+    val inputTimeTaken : Float
 ) {
     companion object {
-        /**
-         * aiProcessingStatisticsId가 존재하지 않는, Form으로 생성된 이벤트의 Entity를 만드는 메서드
-         */
-        fun toEntity(eventData : EventCreateRequestDTO,
-                     calendar : CalendarEntity) : EventEntity {
-            return EventEntity(
-                uid = EventUID.genUID(),
-                summary = eventData.summary,
-                description = eventData.description,
-                startAt = eventData.startAt,
-                endAt = eventData.endAt,
-                priority = eventData.priority,
-                location = eventData.location,
-                repeatRule = eventData.repeatRule,
-                calendar = calendar,
-                eventGroupId = eventData.eventGroupId,
-                colorSetId = eventData.colorSetId,
-                status = eventData.status,
-                transp = eventData.transp,
-                alarm = eventData.alarmId,
-            )
-        }
-
-        /**
-         * ai processing을 거쳐, aiProcessingStatisticsId를 함께 던져준 상태에서 적용.
-         *
-         * statistics 객체를 넣느냐 마느냐가 ai 답변인지 가르는 분기 플래그가 됨.
-         */
-
         fun toEntity(eventData : EventCreateRequestDTO,
                      calendar : CalendarEntity,
-                     aiProcessingStatisticsEntity: AiProcessingStatisticsEntity) : EventEntity {
+                     eventGroup : EventGroupEntity?,
+                     alarm : AlarmEntity?,
+                     aiProcessingStatisticsEntity: AiProcessingStatisticsEntity?) : EventEntity {
             return EventEntity(
                 uid = EventUID.genUID(),
                 summary = eventData.summary,
@@ -99,11 +94,11 @@ open class EventCreateRequestDTO(
                 location = eventData.location,
                 repeatRule = eventData.repeatRule,
                 calendar = calendar,
-                eventGroupId = eventData.eventGroupId,
+                eventGroup = eventGroup,
                 colorSetId = eventData.colorSetId,
                 status = eventData.status,
                 transp = eventData.transp,
-                alarm = eventData.alarmId,
+                alarm = alarm,
                 aiProcessingStatistics = aiProcessingStatisticsEntity
             )
         }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -1,0 +1,77 @@
+package com.dnight.calinify.event.dto.request
+
+import com.dnight.calinify.calendar.entity.CalendarEntity
+import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.entity.EventStatus
+import com.dnight.calinify.event.entity.EventTransp
+import com.dnight.calinify.event.entity.EventUID
+import com.fasterxml.jackson.annotation.JsonFormat
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+data class EventCreateRequestDTO(
+    @field:NotEmpty
+    val summary: String,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val startAt: LocalDateTime,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val endAt: LocalDateTime,
+
+    @field:Size(max = 2047)
+    val description : String?,
+
+    @field:Size(min = 1, max= 9)
+    val priority : Short = 5,
+
+    @field:Size(max = 255)
+    val location : String? = null,
+
+    @field:Size(max = 255)
+    val refeatRule : String? = null,
+
+    @field:Min(1)
+    val calendarId: Long,
+
+    @field:Min(1)
+    val eventGroupId : Long,
+
+    @field:Min(1)
+    val colorSetId : Int,
+
+    @Enumerated(EnumType.STRING)
+    val status : EventStatus,
+
+    @Enumerated(EnumType.STRING)
+    val transp : EventTransp,
+
+    val alarmId : Long? = null
+) {
+    companion object {
+        fun toEntity(eventData : EventCreateRequestDTO,
+                     calendar : CalendarEntity) : EventEntity {
+            return EventEntity(
+                uid = EventUID.genUID(),
+                summary = eventData.summary,
+                description = eventData.description,
+                startAt = eventData.startAt,
+                endAt = eventData.endAt,
+                priority = eventData.priority,
+                location = eventData.location,
+                refeatRule = eventData.refeatRule,
+                calendar = calendar,
+                eventGroupId = eventData.eventGroupId,
+                colorSetId = eventData.colorSetId,
+                status = eventData.status,
+                transp = eventData.transp,
+                alarmId = eventData.alarmId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -8,7 +8,6 @@ import com.dnight.calinify.event.entity.EventUID
 import com.fasterxml.jackson.annotation.JsonFormat
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
@@ -34,7 +33,7 @@ data class EventCreateRequestDTO(
     val location : String? = null,
 
     @field:Size(max = 255)
-    val refeatRule : String? = null,
+    val repeatRule : String? = null,
 
     @field:Min(1)
     val calendarId: Long,
@@ -64,7 +63,7 @@ data class EventCreateRequestDTO(
                 endAt = eventData.endAt,
                 priority = eventData.priority,
                 location = eventData.location,
-                refeatRule = eventData.refeatRule,
+                repeatRule = eventData.repeatRule,
                 calendar = calendar,
                 eventGroupId = eventData.eventGroupId,
                 colorSetId = eventData.colorSetId,

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -42,7 +42,7 @@ data class EventCreateRequestDTO(
     val eventGroupId : Long,
 
     @field:Min(1)
-    val colorSetId : Int,
+    val colorSetId : Int? = null,
 
     @Enumerated(EnumType.STRING)
     val status : EventStatus,
@@ -69,7 +69,7 @@ data class EventCreateRequestDTO(
                 colorSetId = eventData.colorSetId,
                 status = eventData.status,
                 transp = eventData.transp,
-                alarmId = eventData.alarmId
+                alarm = eventData.alarmId
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -1,6 +1,7 @@
 package com.dnight.calinify.event.dto.response
 
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
+import com.dnight.calinify.alarm.dto.response.AlarmResponseDTO
 import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.entity.EventStatus
 import com.dnight.calinify.event.entity.EventTransp
@@ -17,8 +18,8 @@ class EventResponseDTO(
     val repeatRule : String? = null,
     val status : EventStatus,
     val transp : EventTransp,
-    // TODO 알람 추가
-    val alarmId : Long? = null
+//    val eventGroup : EventGroupEntity? = null,
+    val alarm : AlarmResponseDTO? = null
 ): AiResponseDTO() {
     companion object {
         fun from(event: EventEntity) : EventResponseDTO {
@@ -33,7 +34,9 @@ class EventResponseDTO(
                 repeatRule = event.repeatRule,
                 status = event.status,
                 transp = event.transp,
-                alarmId = event.alarm
+                alarm = event.alarm?.let { AlarmResponseDTO.from(it) },
+//                eventGroup = event.eventGroup?.let { EventGroupResponseDTO.from(it) }
+//                alarm = if (event.alarm != null) AlarmResponseDTO.from(event.alarm!!) else null
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -1,12 +1,12 @@
 package com.dnight.calinify.event.dto.response
 
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.entity.EventStatus
 import com.dnight.calinify.event.entity.EventTransp
-import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import java.time.LocalDateTime
 
-data class EventResponseDTO(
+class EventResponseDTO(
     val eventId : Long,
     val summary : String,
     val description : String? = null,

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -29,7 +29,7 @@ data class EventResponseDTO(
                 endAt = event.endAt,
                 priority = event.priority,
                 location = event.location,
-                repeatRule = event.refeatRule,
+                repeatRule = event.repeatRule,
                 status = event.status,
                 transp = event.transp,
                 alarmId = event.alarmId

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -1,0 +1,39 @@
+package com.dnight.calinify.event.dto.response
+
+import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.entity.EventStatus
+import com.dnight.calinify.event.entity.EventTransp
+import java.time.LocalDateTime
+
+data class EventResponseDTO(
+    val eventId : Long,
+    val summary : String,
+    val description : String? = null,
+    val startAt : LocalDateTime,
+    val endAt : LocalDateTime,
+    val priority : Short,
+    val location : String? = null,
+    val repeatRule : String? = null,
+    val status : EventStatus,
+    val transp : EventTransp,
+    // TODO 알람 추가
+    val alarmId : Long? = null
+) {
+    companion object {
+        fun from(event: EventEntity) : EventResponseDTO {
+            return EventResponseDTO(
+                eventId = event.eventId!!,
+                summary = event.summary,
+                description = event.description,
+                startAt = event.startAt,
+                endAt = event.endAt,
+                priority = event.priority,
+                location = event.location,
+                repeatRule = event.refeatRule,
+                status = event.status,
+                transp = event.transp,
+                alarmId = event.alarmId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -3,6 +3,7 @@ package com.dnight.calinify.event.dto.response
 import com.dnight.calinify.event.entity.EventEntity
 import com.dnight.calinify.event.entity.EventStatus
 import com.dnight.calinify.event.entity.EventTransp
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import java.time.LocalDateTime
 
 data class EventResponseDTO(
@@ -11,14 +12,14 @@ data class EventResponseDTO(
     val description : String? = null,
     val startAt : LocalDateTime,
     val endAt : LocalDateTime,
-    val priority : Short,
+    val priority : Short?,
     val location : String? = null,
     val repeatRule : String? = null,
     val status : EventStatus,
     val transp : EventTransp,
     // TODO 알람 추가
     val alarmId : Long? = null
-) {
+): AiResponseDTO() {
     companion object {
         fun from(event: EventEntity) : EventResponseDTO {
             return EventResponseDTO(
@@ -32,7 +33,7 @@ data class EventResponseDTO(
                 repeatRule = event.repeatRule,
                 status = event.status,
                 transp = event.transp,
-                alarmId = event.alarmId
+                alarmId = event.alarm
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "event")
-data class EventEntity(
+open class EventEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val eventId : Long? = 0,
@@ -37,7 +37,7 @@ data class EventEntity(
     var location : String?,
 
     @Column(nullable = true, length = 255)
-    var refeatRule : String? = null,
+    var repeatRule : String? = null,
 
     @Column(nullable = false)
     var isDeleted : Short = 0,

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
@@ -1,5 +1,6 @@
 package com.dnight.calinify.event.entity
 
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import com.dnight.calinify.config.basicEntity.BasicEntity
 import jakarta.persistence.*
@@ -63,5 +64,13 @@ class EventEntity(
 
     @Column(nullable = true)
     var colorSetId : Int? = null,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_processing_statistics_id")
+    var aiProcessingStatistics: AiProcessingStatisticsEntity? = null,
+
+//    @OneToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "ai_processing_event_statistics_id")
+//    val aiProcessingEventStatistics: AiProcessingStatisticsEntity
 
     ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
@@ -1,0 +1,67 @@
+package com.dnight.calinify.event.entity
+
+import com.dnight.calinify.calendar.entity.CalendarEntity
+import com.dnight.calinify.config.basicEntity.BasicEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "event")
+data class EventEntity(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val eventId : Long? = 0,
+
+    @Column(nullable = false, unique = true, length = 255)
+    val uid : String,
+
+    @Column(nullable = false, length = 50)
+    var summary : String,
+
+    @Column(nullable = false)
+    var sequence : Int = 0,
+
+    @Column(nullable = false)
+    var startAt : LocalDateTime,
+
+    @Column(nullable = false)
+    var endAt : LocalDateTime,
+
+    @Column(nullable = true, length = 2047)
+    var description : String?,
+
+    @Column(nullable = false)
+    var priority : Short = 5,
+
+    @Column(nullable = true, length = 255)
+    var location : String?,
+
+    @Column(nullable = true, length = 255)
+    var refeatRule : String? = null,
+
+    @Column(nullable = false)
+    var isDeleted : Short = 0,
+
+    @JoinColumn(name = "calendarId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    val calendar : CalendarEntity,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status : EventStatus,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val transp : EventTransp,
+
+    // TODO 이하 속성들은 추후 Entity 생성 시, 조인 컬럼 설정
+    @Column(nullable = true)
+    val eventGroupId : Long,
+
+    @Column(nullable = true)
+    val alarmId : Long? = null,
+
+    @Column(nullable = true)
+    var colorSetId : Int,
+
+    ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
@@ -7,10 +7,10 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "event")
-open class EventEntity(
+class EventEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val eventId : Long? = 0,
+    var eventId : Long? = 0,
 
     @Column(nullable = false, unique = true, length = 255)
     val uid : String,
@@ -31,7 +31,7 @@ open class EventEntity(
     var description : String?,
 
     @Column(nullable = false)
-    var priority : Short = 5,
+    var priority : Short? = 5,
 
     @Column(nullable = true, length = 255)
     var location : String?,
@@ -44,24 +44,24 @@ open class EventEntity(
 
     @JoinColumn(name = "calendarId")
     @ManyToOne(fetch = FetchType.LAZY)
-    val calendar : CalendarEntity,
+    var calendar : CalendarEntity,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status : EventStatus,
+    var status : EventStatus = EventStatus.TENTATIVE,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val transp : EventTransp,
+    var transp : EventTransp = EventTransp.OPAQUE,
 
     // TODO 이하 속성들은 추후 Entity 생성 시, 조인 컬럼 설정
     @Column(nullable = true)
-    val eventGroupId : Long,
+    var eventGroupId : Long? = null,
 
     @Column(nullable = true)
-    val alarmId : Long? = null,
+    var alarm : Long? = null,
 
     @Column(nullable = true)
-    var colorSetId : Int,
+    var colorSetId : Int? = null,
 
     ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventEntity.kt
@@ -1,8 +1,10 @@
 package com.dnight.calinify.event.entity
 
 import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.alarm.entity.AlarmEntity
 import com.dnight.calinify.calendar.entity.CalendarEntity
 import com.dnight.calinify.config.basicEntity.BasicEntity
+import com.dnight.calinify.event_group.entity.EventGroupEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
@@ -55,22 +57,20 @@ class EventEntity(
     @Column(nullable = false)
     var transp : EventTransp = EventTransp.OPAQUE,
 
-    // TODO 이하 속성들은 추후 Entity 생성 시, 조인 컬럼 설정
-    @Column(nullable = true)
-    var eventGroupId : Long? = null,
+    @JoinColumn(name = "event_group_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    var eventGroup : EventGroupEntity? = null,
 
-    @Column(nullable = true)
-    var alarm : Long? = null,
+    @JoinColumn(name = "alarm_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    var alarm : AlarmEntity? = null,
 
+    // 아무리 생각해도 id만 넘겨주고, 색상 관련된 데이터는 FE가 갖고 있는 걸로
     @Column(nullable = true)
     var colorSetId : Int? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ai_processing_statistics_id")
     var aiProcessingStatistics: AiProcessingStatisticsEntity? = null,
-
-//    @OneToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "ai_processing_event_statistics_id")
-//    val aiProcessingEventStatistics: AiProcessingStatisticsEntity
 
     ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "event_history")
-data class EventHistoryEntity(
+class EventHistoryEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val eventHistoryId: Long? = 0,
 

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
@@ -24,7 +24,7 @@ class EventHistoryEntity(
     val endAt : LocalDateTime,
 
     @LastModifiedDate
-    val updatedAt: LocalDateTime,
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(nullable = false, length = 2047)
     val description : String? = null,
@@ -45,22 +45,4 @@ class EventHistoryEntity(
 
     @Column(nullable = false)
     val repeatRule : String? = null
-) {
-    companion object {
-        fun from(event : EventEntity) : EventHistoryEntity {
-            return EventHistoryEntity(
-                event = event,
-                summary = event.summary,
-                startAt = event.startAt,
-                endAt = event.endAt,
-                description = event.description,
-                priority = event.priority,
-                status = event.status,
-                transp = event.transp,
-                location = event.location,
-                repeatRule = event.repeatRule,
-                updatedAt = event.updatedAt
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
@@ -1,0 +1,66 @@
+package com.dnight.calinify.event.entity
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "event_history")
+data class EventHistoryEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val eventHistoryId: Long? = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    val event: EventEntity,
+
+    @Column(nullable = false)
+    val summary: String,
+
+    @Column(nullable = false)
+    val startAt : LocalDateTime,
+
+    @Column(nullable = false)
+    val endAt : LocalDateTime,
+
+    @LastModifiedDate
+    val updatedAt: LocalDateTime,
+
+    @Column(nullable = false, length = 2047)
+    val description : String? = null,
+
+    @Column(nullable = false)
+    val priority: Short? = 5,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: EventStatus = EventStatus.TENTATIVE,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val transp: EventTransp = EventTransp.OPAQUE,
+
+    @Column(nullable = false)
+    val location : String? = null,
+
+    @Column(nullable = false)
+    val repeatRule : String? = null
+) {
+    companion object {
+        fun from(event : EventEntity) : EventHistoryEntity {
+            return EventHistoryEntity(
+                event = event,
+                summary = event.summary,
+                startAt = event.startAt,
+                endAt = event.endAt,
+                description = event.description,
+                priority = event.priority,
+                status = event.status,
+                transp = event.transp,
+                location = event.location,
+                repeatRule = event.repeatRule,
+                updatedAt = event.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.*
 
 @Entity
 @Table(name = "event_statistics")
-data class EventStatisticsEntity(
+class EventStatisticsEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val eventStatisticsId : Long? = 0,
 

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
@@ -1,0 +1,14 @@
+package com.dnight.calinify.event.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "event_statistics")
+data class EventStatisticsEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val eventStatisticsId : Long? = 0,
+
+    val inputTypeId: Short,
+
+    val inputTimeTaken : Float
+)

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatisticsEntity.kt
@@ -1,14 +1,21 @@
 package com.dnight.calinify.event.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
 
 @Entity
 @Table(name = "event_statistics")
 class EventStatisticsEntity(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val eventStatisticsId : Long? = 0,
+    @Id
+    @Column(name = "event_statistics_id", nullable = false)
+    var eventStatisticsId: Long? = null,
 
-    val inputTypeId: Short,
+    @NotNull
+    var inputTypeId: Short,
 
-    val inputTimeTaken : Float
+    @Column(name = "input_time_taken")
+    var inputTimeTaken: Float
 )

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatus.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventStatus.kt
@@ -1,0 +1,5 @@
+package com.dnight.calinify.event.entity
+
+enum class EventStatus {
+    TENTATIVE, CONFIRMED, CANCELLED
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventTransp.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventTransp.kt
@@ -1,0 +1,5 @@
+package com.dnight.calinify.event.entity
+
+enum class EventTransp {
+    OPAQUE, TRANSPARENT
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventUID.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventUID.kt
@@ -1,0 +1,16 @@
+package com.dnight.calinify.event.entity
+
+import java.util.UUID
+
+/**
+ * event의 ics 규격 유일값인 uid를 생성한다.
+ *
+ * UUID + '@' + 도메인 네임으로 한다.
+ */
+class EventUID {
+    companion object {
+        fun genUID() : String {
+            return UUID.randomUUID().toString() + "@calinify.com"
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventHistoryRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventHistoryRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.event.repository
+
+import com.dnight.calinify.event.entity.EventHistoryEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventHistoryRepository : JpaRepository<EventHistoryEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.event.repository
+
+import com.dnight.calinify.event.entity.EventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventRepository : JpaRepository<EventEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventStatisticsRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventStatisticsRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.event.repository
+
+import com.dnight.calinify.event.entity.EventStatisticsEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventStatisticsRepository : JpaRepository<EventStatisticsEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
@@ -1,11 +1,23 @@
 package com.dnight.calinify.event.service
 
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.ai_process.repository.AiProcessingStatisticsRepository
+import com.dnight.calinify.alarm.dto.request.AlarmCreateRequestDTO
+import com.dnight.calinify.alarm.entity.AlarmEntity
+import com.dnight.calinify.alarm.repository.AlarmRepository
+import com.dnight.calinify.alarm.service.AlarmService
 import com.dnight.calinify.calendar.repository.CalendarRepository
 import com.dnight.calinify.config.basicResponse.ResponseCode
 import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.event.dto.EventHistoryDTO
+import com.dnight.calinify.event.dto.EventStatisticsDTO
 import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
 import com.dnight.calinify.event.dto.response.EventResponseDTO
+import com.dnight.calinify.event.repository.EventHistoryRepository
 import com.dnight.calinify.event.repository.EventRepository
+import com.dnight.calinify.event.repository.EventStatisticsRepository
+import com.dnight.calinify.event_group.entity.EventGroupEntity
+import com.dnight.calinify.event_group.repository.EventGroupRepository
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -13,7 +25,14 @@ import org.springframework.stereotype.Service
 @Service
 class EventService(
     private val eventRepository: EventRepository,
+    private val eventGroupRepository: EventGroupRepository,
+    private val alarmRepository: AlarmRepository,
     private val calendarRepository: CalendarRepository,
+    private val eventHistoryRepository: EventHistoryRepository,
+    private val aiProcessingStatisticsRepository: AiProcessingStatisticsRepository,
+
+    private val alarmService: AlarmService,
+    private val eventStatisticsRepository: EventStatisticsRepository,
 ) {
     fun getEventById(eventId : Long) : EventResponseDTO {
 
@@ -26,19 +45,62 @@ class EventService(
 
     @Transactional
     fun createEvent(eventCreateDTO: EventCreateRequestDTO) : EventResponseDTO {
-        val calendarId : Long = eventCreateDTO.calendarId
 
-        val calendarEntity = calendarRepository.findByIdOrNull(calendarId) ?: throw ClientException(ResponseCode.NotFound)
+        //TODO 일정 입력 시, 바쁜 시간대에 추가로 일정이 있는지 없는지 체크하는 기능...
 
-        val eventEntity = EventCreateRequestDTO.toEntity(eventCreateDTO, calendarEntity)
+        // get calendar
+        val calendarEntity = calendarRepository.findByIdOrNull(eventCreateDTO.calendarId) ?: throw ClientException(ResponseCode.NotFound)
 
+        // get event group - eventGroupId가 있을 경우 검색 후 값 집어넣기, 아니면 null 삽입
+        var eventGroupEntity : EventGroupEntity? = null
+        if (eventCreateDTO.eventGroupId is Long) {
+            eventGroupEntity = eventGroupRepository.findByIdOrNull(eventCreateDTO.eventGroupId)
+                ?: throw ClientException(ResponseCode.NotFound)
+        }
+
+        // alarm 생성 정보가 들어올 경우, 알람 생성도 진행, ID 반환받아와서 다시 검색하고 값 넣어줌.
+        // alarm service에서 Entity를 넘길 수 없으니, 그냥 검색해서 다시 넣기.
+        var alarmId : Long? = null
+        if (eventCreateDTO.alarm is AlarmCreateRequestDTO) {
+            alarmId = alarmService.createAlarm(eventCreateDTO.alarm)
+        }
+
+        val alarmEntity: AlarmEntity? = alarmId?. let {
+            alarmRepository.findByIdOrNull(alarmId)
+        }
+
+        // ai statistics가 있으면 연결, 없으면 null
+        var aiStatisticsEntity : AiProcessingStatisticsEntity? = null
+        if (eventCreateDTO.processedEventId is Long) {
+            aiStatisticsEntity = aiProcessingStatisticsRepository.findByIdOrNull(eventCreateDTO.processedEventId)
+                ?: throw ClientException(ResponseCode.NotFound, "ai processing statistics id 값이 입력되었으나, 찾을 수 없음")
+        }
+
+        // event entity 저장
+        var eventEntity = EventCreateRequestDTO.toEntity(eventCreateDTO, calendarEntity, eventGroupEntity, alarmEntity, aiStatisticsEntity)
         try {
-            eventRepository.save(eventEntity)
+            eventEntity = eventRepository.save(eventEntity)
         } catch (ex: Exception) {
-            throw ClientException(ResponseCode.DataSaveFailed)
+            throw ClientException(ResponseCode.DataSaveFailed, "event 저장 실패")
         }
 
         val eventResponseDTO = EventResponseDTO.from(eventEntity)
+
+        // History 추가
+        val eventHistoryEntity = EventHistoryDTO.toEntity(eventResponseDTO, eventEntity)
+        try {
+            eventHistoryRepository.save(eventHistoryEntity)
+        } catch (ex: Exception) {
+            throw ClientException(ResponseCode.DataSaveFailed, "event history 저장 실패")
+        }
+
+        // event statistics 추가
+        val eventStatistics = EventStatisticsDTO.toEntity(eventCreateDTO, eventEntity.eventId!!)
+        try {
+            eventStatisticsRepository.save(eventStatistics)
+        } catch (ex: Exception) {
+            throw ClientException(ResponseCode.DataSaveFailed, "event statistics 저장 실패")
+        }
 
         return eventResponseDTO
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
@@ -1,0 +1,45 @@
+package com.dnight.calinify.event.service
+
+import com.dnight.calinify.calendar.repository.CalendarRepository
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.event.dto.request.EventCreateRequestDTO
+import com.dnight.calinify.event.dto.response.EventResponseDTO
+import com.dnight.calinify.event.repository.EventRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class EventService(
+    private val eventRepository: EventRepository,
+    private val calendarRepository: CalendarRepository,
+) {
+    fun getEventById(eventId : Long) : EventResponseDTO {
+
+        val event = eventRepository.findByIdOrNull(eventId) ?: throw ClientException(ResponseCode.NotFound)
+
+        val eventResponseDTO = EventResponseDTO.from(event)
+
+        return eventResponseDTO
+    }
+
+    @Transactional
+    fun createEvent(eventCreateDTO: EventCreateRequestDTO) : EventResponseDTO {
+        val calendarId : Long = eventCreateDTO.calendarId
+
+        val calendarEntity = calendarRepository.findByIdOrNull(calendarId) ?: throw ClientException(ResponseCode.NotFound)
+
+        val eventEntity = EventCreateRequestDTO.toEntity(eventCreateDTO, calendarEntity)
+
+        try {
+            eventRepository.save(eventEntity)
+        } catch (ex: Exception) {
+            throw ClientException(ResponseCode.DataSaveFailed)
+        }
+
+        val eventResponseDTO = EventResponseDTO.from(eventEntity)
+
+        return eventResponseDTO
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/controller/EventGroupController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/controller/EventGroupController.kt
@@ -1,0 +1,42 @@
+package com.dnight.calinify.event_group.controller
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.event_group.dto.request.EventGroupCreateRequestDTO
+import com.dnight.calinify.event_group.dto.request.EventGroupUpdateRequestDTO
+import com.dnight.calinify.event_group.dto.response.EventGroupResponseDTO
+import com.dnight.calinify.event_group.service.EventGroupService
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/eventGroup")
+@Validated
+class EventGroupController(
+    private val eventGroupService: EventGroupService
+) {
+    @GetMapping("/{eventGroupId}")
+    fun getEventGroupById(@PathVariable eventGroupId: Long) : BasicResponse<EventGroupResponseDTO> {
+
+        val eventGroup = eventGroupService.getEventGroupById(eventGroupId)
+
+        return BasicResponse.ok(eventGroup, ResponseCode.ResponseSuccess)
+    }
+
+    @PostMapping("/")
+    fun createEventGroup(@RequestBody eventGroupCreateRequestDTO: EventGroupCreateRequestDTO)
+    : BasicResponse<Long> {
+        val eventGroup = eventGroupService.createEventGroup(eventGroupCreateRequestDTO)
+
+        return BasicResponse.ok(eventGroup, ResponseCode.CreateSuccess)
+    }
+
+    @PutMapping("/")
+    fun updateEventGroup(@RequestBody eventGroupUpdateRequestDTO: EventGroupUpdateRequestDTO)
+    : BasicResponse<String> {
+        val eventGroup = eventGroupService.updateEventGroup(eventGroupUpdateRequestDTO)
+
+        return BasicResponse.ok("OK", ResponseCode.UpdateSuccess)
+    }
+
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/controller/EventGroupController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/controller/EventGroupController.kt
@@ -17,7 +17,6 @@ class EventGroupController(
 ) {
     @GetMapping("/{eventGroupId}")
     fun getEventGroupById(@PathVariable eventGroupId: Long) : BasicResponse<EventGroupResponseDTO> {
-
         val eventGroup = eventGroupService.getEventGroupById(eventGroupId)
 
         return BasicResponse.ok(eventGroup, ResponseCode.ResponseSuccess)
@@ -39,4 +38,10 @@ class EventGroupController(
         return BasicResponse.ok("OK", ResponseCode.UpdateSuccess)
     }
 
+    @DeleteMapping("/{eventGroupId}")
+    fun deleteEventGroup(@PathVariable eventGroupId: Long) : BasicResponse<String> {
+        eventGroupService.deleteEventGroup(eventGroupId)
+
+        return BasicResponse.ok("OK", ResponseCode.DeleteSuccess)
+    }
 }

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
@@ -1,0 +1,31 @@
+package com.dnight.calinify.event_group.dto.request
+
+import com.dnight.calinify.common.colorSets.ColorSetsEntity
+import com.dnight.calinify.event_group.entity.EventGroupEntity
+import com.dnight.calinify.user.entity.UserEntity
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+
+class EventGroupCreateRequestDTO (
+    @field:Size(min = 1, max = 20)
+    val groupName: String,
+
+    @field:Size(max = 255)
+    val description: String? = null,
+
+    @field:Min(1)
+    val colorSetId: Int? = null,
+) {
+    companion object {
+        fun toEntity(eventGroupCreateRequestDTO: EventGroupCreateRequestDTO,
+                     user: UserEntity,
+                     colorSet: ColorSetsEntity) : EventGroupEntity {
+            return EventGroupEntity(
+                groupName = eventGroupCreateRequestDTO.groupName,
+                description = eventGroupCreateRequestDTO.description,
+                user = user,
+                colorSet = colorSet,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupUpdateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupUpdateRequestDTO.kt
@@ -1,0 +1,18 @@
+package com.dnight.calinify.event_group.dto.request
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+
+class EventGroupUpdateRequestDTO (
+    @field:Min(1)
+    val groupId: Long,
+
+    @field:Size(min = 1, max = 20)
+    val groupName: String,
+
+    @field:Size(max = 255)
+    val description: String? = null,
+
+    @field:Min(1)
+    val colorSetId: Int? = null,
+)

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/response/EventGroupResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/response/EventGroupResponseDTO.kt
@@ -1,0 +1,21 @@
+package com.dnight.calinify.event_group.dto.response
+
+import com.dnight.calinify.event_group.entity.EventGroupEntity
+
+class EventGroupResponseDTO(
+    val groupName: String,
+
+    val description: String? = null,
+
+    val colorSetId: Int? = null,
+) {
+    companion object {
+        fun from(groupEntity: EventGroupEntity) : EventGroupResponseDTO {
+            return EventGroupResponseDTO(
+                groupName = groupEntity.groupName,
+                description = groupEntity.description,
+                colorSetId = groupEntity.colorSet.colorSetId,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
@@ -1,0 +1,29 @@
+package com.dnight.calinify.event_group.entity
+
+import com.dnight.calinify.common.colorSets.ColorSetsEntity
+import com.dnight.calinify.config.basicEntity.BasicEntity
+import com.dnight.calinify.user.entity.UserEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "event_group")
+class EventGroupEntity(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val groupId : Long? = 0,
+
+    @Column(nullable = false)
+    var groupName : String,
+
+    @Column(nullable = true)
+    var description : String? = null,
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    val user : UserEntity,
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    var colorSet : ColorSetsEntity
+
+) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event_group/repository/EventGroupRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/repository/EventGroupRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.event_group.repository
+
+import com.dnight.calinify.event_group.entity.EventGroupEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventGroupRepository : JpaRepository<EventGroupEntity, Long>

--- a/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
@@ -1,0 +1,58 @@
+package com.dnight.calinify.event_group.service
+
+import com.dnight.calinify.common.colorSets.ColorSetsRepository
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.event_group.dto.request.EventGroupCreateRequestDTO
+import com.dnight.calinify.event_group.dto.request.EventGroupUpdateRequestDTO
+import com.dnight.calinify.event_group.dto.response.EventGroupResponseDTO
+import com.dnight.calinify.event_group.repository.EventGroupRepository
+import com.dnight.calinify.user.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class EventGroupService(
+    private val eventGroupRepository: EventGroupRepository,
+    private val userRepository: UserRepository,
+    private val colorSetsRepository: ColorSetsRepository,
+) {
+
+    fun getEventGroupById(eventGroupId : Long) : EventGroupResponseDTO {
+        val eventGroupEntity = eventGroupRepository.findByIdOrNull(eventGroupId)
+            ?: throw ClientException(ResponseCode.NotFound)
+
+        return EventGroupResponseDTO.from(eventGroupEntity)
+    }
+
+    @Transactional
+    fun createEventGroup(eventGroupCreateRequestDTO: EventGroupCreateRequestDTO) : Long {
+
+        // TODO user logic 구현
+        val user = userRepository.findByIdOrNull(1) ?: throw ClientException(ResponseCode.UserNotFound)
+
+        val colorSet = colorSetsRepository.findByIdOrNull(eventGroupCreateRequestDTO.colorSetId)
+            ?: throw ClientException(ResponseCode.NotFound, "color set Id")
+
+        val eventGroupEntity = EventGroupCreateRequestDTO.toEntity(eventGroupCreateRequestDTO, user, colorSet)
+
+        val eventGroup = eventGroupRepository.save(eventGroupEntity)
+
+        return eventGroup.groupId!!
+    }
+
+    @Transactional
+    fun updateEventGroup(eventGroupUpdateRequestDTO: EventGroupUpdateRequestDTO) {
+
+        val eventGroupEntity = eventGroupRepository.findByIdOrNull(eventGroupUpdateRequestDTO.groupId)
+            ?: throw ClientException(ResponseCode.NotFound, "group Id")
+
+        val colorSet = colorSetsRepository.findByIdOrNull(eventGroupUpdateRequestDTO.colorSetId)
+            ?: throw ClientException(ResponseCode.NotFound, "color set Id")
+
+        eventGroupEntity.colorSet = colorSet
+        eventGroupEntity.groupName = eventGroupUpdateRequestDTO.groupName
+        eventGroupEntity.description = eventGroupUpdateRequestDTO.description
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
@@ -55,4 +55,12 @@ class EventGroupService(
         eventGroupEntity.groupName = eventGroupUpdateRequestDTO.groupName
         eventGroupEntity.description = eventGroupUpdateRequestDTO.description
     }
+
+    @Transactional
+    fun deleteEventGroup(eventGroupId: Long) {
+
+        val eventGroupEntity = eventGroupRepository.findByIdOrNull(eventGroupId) ?: throw ClientException(ResponseCode.NotFound)
+
+        eventGroupRepository.delete(eventGroupEntity)
+    }
 }

--- a/src/main/kotlin/com/Dnight/calinify/user/dto/request/GenderEnum.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/dto/request/GenderEnum.kt
@@ -1,0 +1,5 @@
+package com.dnight.calinify.user.dto.request
+
+enum class GenderEnum{
+    male, female
+}

--- a/src/main/kotlin/com/Dnight/calinify/user/dto/request/UserCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/dto/request/UserCreateRequestDTO.kt
@@ -4,18 +4,20 @@ import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 
-data class UserCreateRequestDTO(
+class UserCreateRequestDTO(
     @field:Email
     val email : String,
+
     @field:NotEmpty
     val password : String,
+
     @field:NotEmpty
     val userName : String,
+
     @Enumerated(EnumType.STRING)
-    val gender : Gender?,
+    val gender : GenderEnum?,
     val phoneNumber : String?,
 )  {
     companion object{
@@ -29,8 +31,4 @@ data class UserCreateRequestDTO(
             )
         }
     }
-}
-
-enum class Gender{
-    male, female
 }

--- a/src/main/kotlin/com/Dnight/calinify/user/dto/response/UserCreateResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/dto/response/UserCreateResponseDTO.kt
@@ -2,7 +2,7 @@ package com.dnight.calinify.user.dto.response
 
 import com.dnight.calinify.user.entity.UserEntity
 
-data class UserCreateResponseDTO(
+class UserCreateResponseDTO(
     val userName: String,
     val email: String,
 ) {

--- a/src/main/kotlin/com/Dnight/calinify/user/dto/response/UserProfileResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/dto/response/UserProfileResponseDTO.kt
@@ -1,14 +1,14 @@
 package com.dnight.calinify.user.dto.response
 
-import com.dnight.calinify.user.dto.request.Gender
+import com.dnight.calinify.user.dto.request.GenderEnum
 import com.dnight.calinify.user.entity.UserEntity
 
-data class UserProfileResponseDTO(
+class UserProfileResponseDTO(
     val userId : Long,
     val userName: String,
     val email: String,
     val phoneNumber: String?,
-    val gender: Gender?,
+    val gender: GenderEnum?,
 ) {
     companion object {
         fun from(user: UserEntity) : UserProfileResponseDTO {

--- a/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
@@ -1,11 +1,9 @@
 package com.dnight.calinify.user.entity
 
-import com.dnight.calinify.user.dto.request.Gender
+import com.dnight.calinify.config.basicEntity.BasicEntity
+import com.dnight.calinify.user.dto.request.GenderEnum
 import jakarta.persistence.*
 import jakarta.validation.constraints.Email
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "user")
@@ -23,14 +21,8 @@ class UserEntity (
     @Column(nullable = false)
     val password: String,
 
-    @CreatedDate
-    var createdAt : LocalDateTime? = LocalDateTime.now(),
-
-    @LastModifiedDate
-    var updatedAt : LocalDateTime? = LocalDateTime.now(),
-
     @Enumerated(EnumType.STRING)
-    var gender: Gender?,
+    var gender: GenderEnum?,
 
     val phoneNumber: String?
-)
+) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
@@ -9,13 +9,13 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "user")
-open class UserEntity (
+class UserEntity (
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val userId: Long? = null,
+    var userId: Long? = null,
 
     @Email @Column(nullable = false, unique = true)
-    val email: String,
+    var email: String,
 
     @Column(nullable = false)
     var userName: String,
@@ -24,13 +24,13 @@ open class UserEntity (
     val password: String,
 
     @CreatedDate
-    val createdAt : LocalDateTime? = LocalDateTime.now(),
+    var createdAt : LocalDateTime? = LocalDateTime.now(),
 
     @LastModifiedDate
-    val updatedAt : LocalDateTime? = LocalDateTime.now(),
+    var updatedAt : LocalDateTime? = LocalDateTime.now(),
 
     @Enumerated(EnumType.STRING)
-    val gender: Gender?,
+    var gender: Gender?,
 
     val phoneNumber: String?
 )

--- a/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
@@ -1,7 +1,6 @@
 package com.dnight.calinify.user.entity
 
 import com.dnight.calinify.user.dto.request.Gender
-import com.dnight.calinify.user.dto.request.UserCreateRequestDTO
 import jakarta.persistence.*
 import jakarta.validation.constraints.Email
 import org.springframework.data.annotation.CreatedDate
@@ -10,7 +9,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "user")
-data class UserEntity (
+open class UserEntity (
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val userId: Long? = null,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         show_sql: true
+        format_sql: true
 
 #  security:
 #    oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,11 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         show_sql: true
 
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: https://securetoken.google.com/swm-mobile-client
+#  security:
+#    oauth2:
+#      resourceserver:
+#        jwt:
+#          issuer-uri: https://securetoken.google.com/swm-mobile-client
 
 springdoc:
 


### PR DESCRIPTION
## Result

event ai processing 및 event 등록 구현, alarm, event group 구현

## How

fastAPI로 구현한 event processing 엔드 포인트에 데이터를 넣으면, 정제된 데이터를 가져온다.

ai processing 과정을 거친 일정과 form으로 입력한 일정 모두 등록이 가능하도록 하나의 서비스 함수에서 처리한다.

이벤트 등록과 동시에 statistics와 alarm을 생성하여 함께 입력한다.

alarm과 event group 생성 또한 구현되어 있다.

## Other

clientException의 코드를 일부 수정하여, message에 커스텀 메시지를 추가하여 보여주거나, 기본 메시지를 표시하도록 만들었다.