### PR TITLE
Feat : event 테이블 분할 및 common resource crud 생성

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/auth/dto/request/GoogleUserCreateDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/dto/request/GoogleUserCreateDTO.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.auth.dto.request
 
-import com.dnight.calinify.user.entity.AccountLinkEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -23,14 +22,12 @@ data class GoogleUserCreateDTO(
     val phoneNumber : String? = null,
 ) {
     companion object {
-        fun toEntity(data : GoogleUserCreateDTO,
-                     accountLink : AccountLinkEntity) : UserEntity {
+        fun toEntity(data : GoogleUserCreateDTO) : UserEntity {
             return UserEntity(
                 email = data.email,
                 userName = data.name,
                 gender = data.gender,
                 phoneNumber = data.phoneNumber,
-                accountLink = accountLink
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/auth/dto/request/UserCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/dto/request/UserCreateRequestDTO.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.auth.dto.request
 
-import com.dnight.calinify.user.entity.AccountLinkEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -25,15 +24,13 @@ class UserCreateRequestDTO(
     val phoneNumber : String?,
 )  {
     companion object{
-        fun toEntity(userCreateRequestDTO: UserCreateRequestDTO,
-                     accountLink : AccountLinkEntity): UserEntity {
+        fun toEntity(userCreateRequestDTO: UserCreateRequestDTO): UserEntity {
             return UserEntity(
                 email = userCreateRequestDTO.email,
                 password = userCreateRequestDTO.password,
                 userName = userCreateRequestDTO.userName,
                 gender = userCreateRequestDTO.gender,
                 phoneNumber = userCreateRequestDTO.phoneNumber,
-                accountLink = accountLink
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/service/AuthService.kt
@@ -37,23 +37,27 @@ class AuthService(
 
     @Transactional
     fun createUser(userCreateRequestDTO: UserCreateRequestDTO) : UserCreateResponseDTO {
-        val accountLinkEntity = AccountLinkEntity()
-        val accountLink = accountLinkRepository.save(accountLinkEntity)
 
         // 비밀번호 암호화
         userCreateRequestDTO.password = passwordEncoder.encode(userCreateRequestDTO.password)
 
-        val newUser = UserCreateRequestDTO.toEntity(userCreateRequestDTO, accountLink)
-        userRepository.save(newUser)
+        val user = UserCreateRequestDTO.toEntity(userCreateRequestDTO)
+        val newUser = userRepository.save(user)
+
+        val accountLinkEntity = AccountLinkEntity(newUser.userId!!, newUser, null, null)
+
+        newUser.addAccountLink(accountLinkEntity)
+
         return UserCreateResponseDTO.from(newUser)
     }
 
     @Transactional
     fun createGoogleUser(googleUserCreateDTO: GoogleUserCreateDTO) : UserCreateResponseDTO {
-        val accountLink = AccountLinkEntity(google = googleUserCreateDTO.uid)
+        val user = GoogleUserCreateDTO.toEntity(googleUserCreateDTO)
+        val newUser = userRepository.save(user)
 
-        val newUser = GoogleUserCreateDTO.toEntity(googleUserCreateDTO, accountLink)
-        userRepository.save(newUser)
+        val accountLink = AccountLinkEntity(newUser.userId!!, newUser, google = googleUserCreateDTO.uid)
+        accountLinkRepository.save(accountLink)
 
         return UserCreateResponseDTO.from(newUser)
     }

--- a/src/main/kotlin/com/Dnight/calinify/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/service/AuthService.kt
@@ -7,6 +7,7 @@ import com.dnight.calinify.auth.dto.response.TokenResponseDTO
 import com.dnight.calinify.auth.dto.response.UserCreateResponseDTO
 import com.dnight.calinify.auth.jwt.JwtTokenProvider
 import com.dnight.calinify.user.entity.AccountLinkEntity
+import com.dnight.calinify.user.repository.AccountLinkRepository
 import com.dnight.calinify.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -19,7 +20,8 @@ class AuthService(
     private val authenticationManagerBuilder: AuthenticationManagerBuilder,
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val jwtTokenProvider: JwtTokenProvider
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val accountLinkRepository: AccountLinkRepository
 ) {
 
     fun login(formLoginDTO: FormLoginDTO): TokenResponseDTO {
@@ -35,7 +37,8 @@ class AuthService(
 
     @Transactional
     fun createUser(userCreateRequestDTO: UserCreateRequestDTO) : UserCreateResponseDTO {
-        val accountLink = AccountLinkEntity()
+        val accountLinkEntity = AccountLinkEntity()
+        val accountLink = accountLinkRepository.save(accountLinkEntity)
 
         // 비밀번호 암호화
         userCreateRequestDTO.password = passwordEncoder.encode(userCreateRequestDTO.password)

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetController.kt
@@ -1,0 +1,53 @@
+package com.dnight.calinify.common.colorSet
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.basicResponse.ResponseOk
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/colorSet")
+class ColorSetController(
+    private val colorSetService: ColorSetService,
+) {
+    @GetMapping("/{colorSetId}")
+    fun getColorSet(@PathVariable colorSetId : Int) : BasicResponse<ColorSetResponseDTO> {
+
+        val colorSet = colorSetService.getColorSet(colorSetId)
+
+        return BasicResponse.ok(colorSet, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping("/")
+    fun getAllColorSet() : BasicResponse<List<ColorSetResponseDTO>> {
+
+        val colorSets : List<ColorSetResponseDTO> = colorSetService.getAllColorSets()
+
+        return BasicResponse.ok(colorSets, ResponseCode.ResponseSuccess)
+    }
+
+    @PostMapping("/")
+    fun createColorSet(@RequestBody colorSetRequestDTO: ColorSetRequestDTO) : BasicResponse<ResponseOk> {
+
+        colorSetService.createColorSet(colorSetRequestDTO)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.CreateSuccess)
+    }
+
+    @PutMapping("/")
+    fun updateColorSet(@RequestBody colorSetRequestDTO: ColorSetRequestDTO) : BasicResponse<ResponseOk> {
+
+        colorSetService.updateColorSet(colorSetRequestDTO)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.UpdateSuccess)
+    }
+
+    @DeleteMapping("/{colorSetId}")
+    fun deleteColorSet(@PathVariable colorSetId : Int) : BasicResponse<ResponseOk> {
+
+        colorSetService.deleteColorSet(colorSetId)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.DeleteSuccess)
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetEntity.kt
@@ -1,13 +1,13 @@
-package com.dnight.calinify.common.colorSets
+package com.dnight.calinify.common.colorSet
 
 import jakarta.persistence.*
 
-@Table(name = "color_sets")
 @Entity
-data class ColorSetsEntity(
+@Table(name = "color_set")
+class ColorSetEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val colorSetId : Int = 0,
+    val colorSetId : Int? = null,
 
     @Column(nullable = false, length = 20)
     val colorName : String,

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetEntity.kt
@@ -10,8 +10,8 @@ class ColorSetEntity(
     val colorSetId : Int? = null,
 
     @Column(nullable = false, length = 20)
-    val colorName : String,
+    var colorName : String,
 
     @Column(nullable = false, length = 20)
-    val hexCode : String,
+    var hexCode : String,
 )

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetRepository.kt
@@ -1,0 +1,5 @@
+package com.dnight.calinify.common.colorSet
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ColorSetRepository : JpaRepository<ColorSetEntity, Int>

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetRequestDTO.kt
@@ -1,0 +1,25 @@
+package com.dnight.calinify.common.colorSet
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+class ColorSetRequestDTO(
+    @field:Min(1)
+    val colorSetId : Int? = null,
+
+    @field:NotBlank
+    val colorSetName : String,
+
+    @field:NotBlank
+    val hexCode : String
+) {
+    companion object {
+        fun toEntity(colorSetRequestDTO: ColorSetRequestDTO) : ColorSetEntity {
+            return ColorSetEntity(
+                colorSetId = colorSetRequestDTO.colorSetId,
+                colorName = colorSetRequestDTO.colorSetName,
+                hexCode = colorSetRequestDTO.hexCode,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetResponseDTO.kt
@@ -1,0 +1,19 @@
+package com.dnight.calinify.common.colorSet
+
+data class ColorSetResponseDTO(
+    val colorSetId : Int,
+
+    val colorName : String,
+
+    val hexCode : String,
+) {
+    companion object {
+        fun from(colorSetEntity : ColorSetEntity) : ColorSetResponseDTO {
+            return ColorSetResponseDTO(
+                colorSetId = colorSetEntity.colorSetId!!,
+                colorName = colorSetEntity.colorName,
+                hexCode = colorSetEntity.hexCode,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSet/ColorSetService.kt
@@ -1,0 +1,66 @@
+package com.dnight.calinify.common.colorSet
+
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.config.exception.ServerSideException
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+
+@Service
+class ColorSetService(
+    private val colorSetRepository: ColorSetRepository
+) {
+    fun getColorSet(colorSetId : Int) : ColorSetResponseDTO {
+
+        val colorSet = colorSetRepository.findByIdOrNull(colorSetId) ?: throw ClientException(ResponseCode.NotFound)
+
+        return ColorSetResponseDTO.from(colorSet)
+    }
+
+    fun getAllColorSets(): List<ColorSetResponseDTO> {
+
+        val colorSets = colorSetRepository.findAll()
+
+        return colorSets.map { ColorSetResponseDTO.from(it) }
+    }
+
+    @Transactional
+    fun createColorSet(colorSetRequestDTO: ColorSetRequestDTO) : Boolean {
+
+        val colorSetEntity = ColorSetRequestDTO.toEntity(colorSetRequestDTO)
+
+        try {
+            colorSetRepository.save(colorSetEntity)
+        } catch (ex : Exception) {
+            throw ServerSideException(ResponseCode.DataSaveFailed)
+        }
+
+        return true
+    }
+
+    @Transactional
+    fun updateColorSet(colorSetRequestDTO: ColorSetRequestDTO) : Boolean {
+
+        val colorSet = colorSetRepository.findByIdOrNull(colorSetRequestDTO.colorSetId)
+            ?: throw ClientException(ResponseCode.NotFound)
+
+        colorSet.colorName = colorSetRequestDTO.colorSetName
+        colorSet.hexCode = colorSetRequestDTO.hexCode
+
+        return true
+    }
+
+    @Transactional
+    fun deleteColorSet(colorSetId: Int): Boolean {
+
+        try {
+            colorSetRepository.deleteById(colorSetId)
+        } catch (ex : Exception) {
+            throw ServerSideException(ResponseCode.DeleteFailed)
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/colorSets/ColorSetsRepository.kt
@@ -1,5 +1,0 @@
-package com.dnight.calinify.common.colorSets
-
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface ColorSetsRepository : JpaRepository<ColorSetsEntity, Int>

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeController.kt
@@ -1,0 +1,54 @@
+package com.dnight.calinify.common.inputType
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.basicResponse.ResponseOk
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/inputType")
+class InputTypeController(
+    private val inputTypeService: InputTypeService
+) {
+    @GetMapping("/{inputTypeId}")
+    fun getInputTypeById(@PathVariable inputTypeId : Int) : BasicResponse<InputTypeResponseDTO> {
+
+        val inputType = inputTypeService.getInputTypeById(inputTypeId)
+
+        return BasicResponse.ok(inputType, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping()
+    fun getAllInputType() : BasicResponse<List<InputTypeResponseDTO>> {
+
+        val inputTypes = inputTypeService.getAllInputTypes()
+
+        return BasicResponse.ok(inputTypes, ResponseCode.ResponseSuccess)
+    }
+
+    @PostMapping("/")
+    fun createInputType(@RequestBody inputTypeRequestDTO: InputTypeRequestDTO) : BasicResponse<ResponseOk> {
+
+        inputTypeService.createInputType(inputTypeRequestDTO)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.CreateSuccess)
+    }
+
+    @PutMapping("/{inputTypeId}")
+    fun updateInputType(@PathVariable inputTypeId: Int,
+                        @RequestBody inputTypeRequestDTO: InputTypeRequestDTO): BasicResponse<ResponseOk> {
+
+        inputTypeService.updateInputType(inputTypeId, inputTypeRequestDTO)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.UpdateSuccess)
+    }
+
+    @DeleteMapping("/{inputTypeId}")
+    fun deleteInputType(@PathVariable inputTypeId : Int) : BasicResponse<ResponseOk> {
+
+        inputTypeService.deleteInputType(inputTypeId)
+
+        return BasicResponse.ok(ResponseOk(), ResponseCode.DeleteSuccess)
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeController.kt
@@ -19,7 +19,7 @@ class InputTypeController(
         return BasicResponse.ok(inputType, ResponseCode.ResponseSuccess)
     }
 
-    @GetMapping()
+    @GetMapping("/")
     fun getAllInputType() : BasicResponse<List<InputTypeResponseDTO>> {
 
         val inputTypes = inputTypeService.getAllInputTypes()

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeEntity.kt
@@ -7,8 +7,8 @@ import jakarta.persistence.*
 data class InputTypeEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val inputTypeId: Long,
+    val inputTypeId: Int? = null,
 
     @Column(nullable = false, length = 50)
-    val inputType: String
+    var inputType: String
 )

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeRepository.kt
@@ -2,4 +2,4 @@ package com.dnight.calinify.common.inputType
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface InputTypeRepository : JpaRepository<InputTypeEntity, Long>
+interface InputTypeRepository : JpaRepository<InputTypeEntity, Int>

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeRequestDTO.kt
@@ -1,0 +1,9 @@
+package com.dnight.calinify.common.inputType
+
+import jakarta.validation.constraints.NotBlank
+
+class InputTypeRequestDTO(
+
+    @field:NotBlank
+    val inputType : String
+)

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeResponseDTO.kt
@@ -1,0 +1,15 @@
+package com.dnight.calinify.common.inputType
+
+class InputTypeResponseDTO(
+    val inputTypeId : Int,
+
+    val inputType : String,
+) {
+    companion object {
+        fun from(inputTypeEntity: InputTypeEntity) : InputTypeResponseDTO {
+            return InputTypeResponseDTO(
+                inputTypeId = inputTypeEntity.inputTypeId!!,
+                inputType = inputTypeEntity.inputType)
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/common/inputType/InputTypeService.kt
@@ -1,0 +1,59 @@
+package com.dnight.calinify.common.inputType
+
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
+import com.dnight.calinify.config.exception.ServerSideException
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class InputTypeService(
+    private val inputTypeRepository: InputTypeRepository
+) {
+    fun getInputTypeById(inputTypeId : Int) : InputTypeResponseDTO {
+        val inputType = inputTypeRepository.findByIdOrNull(inputTypeId)
+            ?: throw ClientException(ResponseCode.NotFound, "input type id")
+
+        return InputTypeResponseDTO(inputType.inputTypeId!!, inputType.inputType)
+    }
+
+    fun getAllInputTypes() : List<InputTypeResponseDTO> {
+
+        val inputTypes = inputTypeRepository.findAll()
+
+        return inputTypes.map { InputTypeResponseDTO.from(it) }
+    }
+
+    @Transactional
+    fun createInputType(inputTypeRequestDTO: InputTypeRequestDTO) : Boolean {
+
+        val inputType = InputTypeEntity(null, inputTypeRequestDTO.inputType)
+
+        inputTypeRepository.save(inputType)
+
+        return true
+    }
+
+    @Transactional
+    fun updateInputType(inputTypeId: Int, inputTypeRequestDTO: InputTypeRequestDTO) : Boolean {
+
+        val inputType = inputTypeRepository.findByIdOrNull(inputTypeId)
+            ?: throw ClientException(ResponseCode.NotFound, "input type id")
+
+        inputType.inputType = inputTypeRequestDTO.inputType
+
+        return true
+    }
+
+    @Transactional
+    fun deleteInputType(inputTypeId: Int) : Boolean {
+        try {
+            inputTypeRepository.deleteById(inputTypeId)
+        } catch (e: Exception) {
+            throw ServerSideException(ResponseCode.DeleteFailed)
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ResponseCode.kt
@@ -59,6 +59,7 @@ enum class ResponseCode(val statusCode: Int, var message: String) {
 
     // 500 - 서버 에러
     DataSaveFailed(500, "데이터 저장 실패"),
+    DeleteFailed(500, "리소스 삭제 실패"),
 
     AiRequestFail(500, "Ai 서버와 통신 실패")
     ;

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventListController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventListController.kt
@@ -1,0 +1,32 @@
+package com.dnight.calinify.event.controller
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.event.dto.response.EventMainResponseDTO
+import com.dnight.calinify.event.service.EventListService
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/eventList")
+@Validated
+class EventListController(
+    private val eventListService: EventListService
+) {
+    @GetMapping("/month")
+    fun getMonthEventList(@RequestParam(defaultValue = "2024") year: Int,
+                          @RequestParam(required = true) month: Int,
+                          @AuthenticationPrincipal userDetails: UserDetails
+                          ): BasicResponse<List<EventMainResponseDTO>>{
+        val userId = userDetails.username.toLong()
+        val eventList = eventListService.getMonthEventList(year, month, userId)
+
+        return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/EventHistoryDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/EventHistoryDTO.kt
@@ -1,22 +1,26 @@
 package com.dnight.calinify.event.dto
 
-import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.entity.EventDetailEntity
 import com.dnight.calinify.event.entity.EventHistoryEntity
+import com.dnight.calinify.event.entity.EventMainEntity
 
 class EventHistoryDTO() {
     companion object {
-        fun toEntity(event: EventEntity): EventHistoryEntity {
+        fun toEntity(eventMainEntity: EventMainEntity,
+                     eventDetailEntity: EventDetailEntity): EventHistoryEntity {
             return EventHistoryEntity(
-                event = event,
-                summary = event.summary,
-                startAt = event.startAt,
-                endAt = event.endAt,
-                description = event.description,
-                priority = event.priority,
-                status = event.status,
-                transp = event.transp,
-                repeatRule = event.repeatRule,
-                location = event.location,
+                event = eventDetailEntity,
+
+                summary = eventMainEntity.summary,
+                startAt = eventMainEntity.startAt,
+                endAt = eventMainEntity.endAt,
+                priority = eventMainEntity.priority,
+                repeatRule = eventMainEntity.repeatRule,
+
+                description = eventDetailEntity.description,
+                status = eventDetailEntity.status,
+                transp = eventDetailEntity.transp,
+                location = eventDetailEntity.location,
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -1,13 +1,10 @@
 package com.dnight.calinify.event.dto.request
 
-import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
 import com.dnight.calinify.alarm.dto.request.AlarmCreateRequestDTO
 import com.dnight.calinify.alarm.entity.AlarmEntity
 import com.dnight.calinify.calendar.entity.CalendarEntity
-import com.dnight.calinify.event.entity.EventEntity
-import com.dnight.calinify.event.entity.EventStatus
-import com.dnight.calinify.event.entity.EventTransp
-import com.dnight.calinify.event.entity.EventUID
+import com.dnight.calinify.event.entity.*
 import com.dnight.calinify.event_group.entity.EventGroupEntity
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
@@ -78,27 +75,34 @@ class EventCreateRequestDTO(
     val inputTimeTaken : Float
 ) {
     companion object {
-        fun toEntity(eventData : EventCreateRequestDTO,
-                     calendar : CalendarEntity,
-                     eventGroup : EventGroupEntity?,
-                     alarm : AlarmEntity?,
-                     aiProcessingStatisticsEntity: AiProcessingStatisticsEntity?) : EventEntity {
-            return EventEntity(
-                uid = EventUID.genUID(),
+        fun toMainEntity(eventData : EventCreateRequestDTO,
+                         calendar : CalendarEntity) : EventMainEntity {
+            return EventMainEntity(
                 summary = eventData.summary,
-                description = eventData.description,
                 startAt = eventData.startAt,
                 endAt = eventData.endAt,
                 priority = eventData.priority,
-                location = eventData.location,
                 repeatRule = eventData.repeatRule,
                 calendar = calendar,
+                colorSetId = eventData.colorSetId
+            )
+        }
+
+        fun toDetailEntity(eventMainEntity: EventMainEntity,
+                           eventData : EventCreateRequestDTO,
+                           eventGroup : EventGroupEntity?,
+                           alarm : AlarmEntity?,
+                           aiProcessingEventEntity: AiProcessingEventEntity?) : EventDetailEntity {
+            return EventDetailEntity(
+                eventMain = eventMainEntity,
+                uid = EventUID.genUID(),
+                description = eventData.description,
+                location = eventData.location,
                 eventGroup = eventGroup,
-                colorSetId = eventData.colorSetId,
                 status = eventData.status,
                 transp = eventData.transp,
                 alarm = alarm,
-                aiProcessingStatistics = aiProcessingStatisticsEntity
+                aiProcessingEvent = aiProcessingEventEntity
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -94,6 +94,7 @@ class EventCreateRequestDTO(
                            alarm : AlarmEntity?,
                            aiProcessingEventEntity: AiProcessingEventEntity?) : EventDetailEntity {
             return EventDetailEntity(
+                eventDetailId = eventMainEntity.eventId,
                 eventMain = eventMainEntity,
                 uid = EventUID.genUID(),
                 description = eventData.description,

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventUpdateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventUpdateRequestDTO.kt
@@ -30,7 +30,7 @@ class EventUpdateRequestDTO(
     @field:Min(1)
     @field:Max(9)
     @Schema(description = "일정의 중요도. 1-9이며 입력이 없으면 기본값 5", defaultValue = "5")
-    val priority : Int?,
+    val priority : Int = 5,
 
     @field:Size(max = 255)
     @Schema(description = "일정의 장소")

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventMainResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventMainResponseDTO.kt
@@ -1,0 +1,30 @@
+package com.dnight.calinify.event.dto.response
+
+import com.dnight.calinify.event.entity.EventMainEntity
+import java.time.LocalDateTime
+
+class EventMainResponseDTO(
+    val eventId : Long,
+    val summary : String,
+    val startAt : LocalDateTime,
+    val endAt : LocalDateTime,
+    val repeatRule : String?,
+    val priority : Int,
+
+    // 1순위로 event entity 자체에 값이 있을 경우, 2순위로 event group 3순위 calendar
+    val colorSetId : Int,
+) {
+    companion object {
+        fun from(event : EventMainEntity) : EventMainResponseDTO {
+            return EventMainResponseDTO(
+                eventId = event.eventId!!,
+                summary = event.summary,
+                startAt = event.startAt,
+                endAt = event.endAt,
+                repeatRule = event.repeatRule,
+                priority = event.priority,
+                colorSetId = event.colorSetId!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -2,13 +2,16 @@ package com.dnight.calinify.event.dto.response
 
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import com.dnight.calinify.alarm.dto.response.AlarmResponseDTO
-import com.dnight.calinify.event.entity.EventEntity
+import com.dnight.calinify.event.entity.EventDetailEntity
+import com.dnight.calinify.event.entity.EventMainEntity
 import com.dnight.calinify.event.entity.EventStatus
 import com.dnight.calinify.event.entity.EventTransp
+import com.dnight.calinify.event_group.dto.response.EventGroupResponseDTO
 import java.time.LocalDateTime
 
 class EventResponseDTO(
     val eventId : Long,
+    val calendarId : Long,
     val summary : String,
     val description : String? = null,
     val startAt : LocalDateTime,
@@ -18,25 +21,27 @@ class EventResponseDTO(
     val repeatRule : String? = null,
     val status : EventStatus,
     val transp : EventTransp,
-//    val eventGroup : EventGroupEntity? = null,
+    val eventGroup : EventGroupResponseDTO? = null,
     val alarm : AlarmResponseDTO? = null
 ): AiResponseDTO() {
     companion object {
-        fun from(event: EventEntity) : EventResponseDTO {
+        fun from(eventMain : EventMainEntity,
+                 eventDetail: EventDetailEntity,) : EventResponseDTO {
             return EventResponseDTO(
-                eventId = event.eventId!!,
-                summary = event.summary,
-                description = event.description,
-                startAt = event.startAt,
-                endAt = event.endAt,
-                priority = event.priority,
-                location = event.location,
-                repeatRule = event.repeatRule,
-                status = event.status,
-                transp = event.transp,
-                alarm = event.alarm?.let { AlarmResponseDTO.from(it) },
-//                eventGroup = event.eventGroup?.let { EventGroupResponseDTO.from(it) }
-//                alarm = if (event.alarm != null) AlarmResponseDTO.from(event.alarm!!) else null
+                eventId = eventMain.eventId!!,
+                calendarId = eventMain.calendar.calendarId,
+                summary = eventMain.summary,
+                startAt = eventMain.startAt,
+                endAt = eventMain.endAt,
+                priority = eventMain.priority,
+                repeatRule = eventMain.repeatRule,
+
+                location = eventDetail.location,
+                description = eventDetail.description,
+                status = eventDetail.status,
+                transp = eventDetail.transp,
+                alarm = eventDetail.alarm?.let { AlarmResponseDTO.from(it) },
+                eventGroup = eventDetail.eventGroup?.let { EventGroupResponseDTO.from(it) }
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventDetailEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventDetailEntity.kt
@@ -1,53 +1,32 @@
 package com.dnight.calinify.event.entity
 
-import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
 import com.dnight.calinify.alarm.entity.AlarmEntity
-import com.dnight.calinify.calendar.entity.CalendarEntity
 import com.dnight.calinify.config.basicEntity.BasicEntity
 import com.dnight.calinify.event_group.entity.EventGroupEntity
 import jakarta.persistence.*
-import java.time.LocalDateTime
 
 @Entity
-@Table(name = "event")
-class EventEntity(
+@Table(name = "event_detail")
+class EventDetailEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var eventId : Long? = 0,
+    var eventDetailId : Long? = 0,
+
+    @OneToOne(mappedBy = "eventDetail", fetch = FetchType.LAZY)
+    val eventMain: EventMainEntity,
 
     @Column(nullable = false, unique = true, length = 255)
     val uid : String,
 
-    @Column(nullable = false, length = 50)
-    var summary : String,
-
     @Column(nullable = false)
     var sequence : Int = 0,
-
-    @Column(nullable = false)
-    var startAt : LocalDateTime,
-
-    @Column(nullable = false)
-    var endAt : LocalDateTime,
 
     @Column(nullable = true, length = 2047)
     var description : String?,
 
-    @Column(nullable = false)
-    var priority : Int? = 5,
-
     @Column(nullable = true, length = 255)
     var location : String?,
-
-    @Column(nullable = true, length = 255)
-    var repeatRule : String? = null,
-
-    @Column(nullable = false)
-    var isDeleted : Int = 0,
-
-    @JoinColumn(name = "calendarId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    var calendar : CalendarEntity,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -65,12 +44,8 @@ class EventEntity(
     @OneToOne(fetch = FetchType.LAZY)
     var alarm : AlarmEntity? = null,
 
-    // 아무리 생각해도 id만 넘겨주고, 색상 관련된 데이터는 FE가 갖고 있는 걸로
-    @Column(nullable = true)
-    var colorSetId : Int? = null,
-
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ai_processing_statistics_id")
-    var aiProcessingStatistics: AiProcessingStatisticsEntity? = null,
+    @JoinColumn(name = "ai_processing_event_id")
+    var aiProcessingEvent: AiProcessingEventEntity? = null,
 
     ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventHistoryEntity.kt
@@ -12,7 +12,7 @@ class EventHistoryEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
-    val event: EventEntity,
+    val event: EventDetailEntity,
 
     @Column(nullable = false)
     val summary: String,

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventMainEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventMainEntity.kt
@@ -1,0 +1,41 @@
+package com.dnight.calinify.event.entity
+
+import com.dnight.calinify.calendar.entity.CalendarEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "event_main")
+class EventMainEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val eventId : Long? = 0,
+
+    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JoinColumn(name = "eventDetailId")
+    val eventDetail: EventDetailEntity? = null,
+
+    @JoinColumn(name = "calendarId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    var calendar : CalendarEntity,
+
+    @Column(nullable = false)
+    var summary : String,
+
+    @Column(nullable = false)
+    var startAt : LocalDateTime,
+
+    @Column(nullable = false)
+    var endAt : LocalDateTime,
+
+    @Column(nullable = false)
+    var priority : Int = 5,
+
+    @Column(nullable = true)
+    var repeatRule : String? = null,
+
+    @Column(nullable = false)
+    var isDeleted : Int = 0,
+
+    @Column(nullable = true)
+    var colorSetId : Int? = null,
+)

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventDetailRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventDetailRepository.kt
@@ -1,0 +1,7 @@
+package com.dnight.calinify.event.repository
+
+import com.dnight.calinify.event.entity.EventDetailEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventDetailRepository : JpaRepository<EventDetailEntity, Long> {
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
@@ -2,7 +2,18 @@ package com.dnight.calinify.event.repository
 
 import com.dnight.calinify.event.entity.EventMainEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface EventMainRepository : JpaRepository<EventMainEntity, Long> {
     fun findByEventIdAndCalendarUserUserId(eventId: Long, userId: Long) : EventMainEntity?
+
+    @Query("SELECT e FROM EventMainEntity e JOIN e.calendar c WHERE" +
+            "((e.endAt >= :startMonth AND e.endAt <= :endMonth) OR" +
+            "(e.startAt >= :startMonth AND e.startAt <= :endMonth))" +
+            "AND c.user.userId = :userId AND e.isDeleted = 0")
+    fun findUserEventBetween(@Param("startMonth") startMonth : LocalDateTime,
+                             @Param("endMonth") endMonth : LocalDateTime,
+                             @Param("userId") userId: Long): List<EventMainEntity>
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
@@ -1,0 +1,8 @@
+package com.dnight.calinify.event.repository
+
+import com.dnight.calinify.event.entity.EventMainEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventMainRepository : JpaRepository<EventMainEntity, Long> {
+    fun findByEventIdAndCalendarUserUserId(eventId: Long, userId: Long) : EventMainEntity?
+}

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventRepository.kt
@@ -1,8 +1,0 @@
-package com.dnight.calinify.event.repository
-
-import com.dnight.calinify.event.entity.EventEntity
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface EventRepository : JpaRepository<EventEntity, Long> {
-    fun findByEventIdAndCalendarUserUserId(eventId: Long, userId: Long) : EventEntity?
-}

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventListService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventListService.kt
@@ -1,0 +1,24 @@
+package com.dnight.calinify.event.service
+
+import com.dnight.calinify.event.dto.response.EventMainResponseDTO
+import com.dnight.calinify.event.entity.EventMainEntity
+import com.dnight.calinify.event.repository.EventMainRepository
+import com.dnight.calinify.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class EventListService(
+    private val eventMainRepository: EventMainRepository,
+    private val userRepository: UserRepository,
+) {
+    fun getMonthEventList(year: Int, month: Int, userId: Long) : List<EventMainResponseDTO> {
+        val startMonth : LocalDateTime = LocalDateTime.of(year, month, 0, 0, 0)
+        val endMonth : LocalDateTime = startMonth.minusSeconds(1)
+        val eventList : List<EventMainEntity> = eventMainRepository.findUserEventBetween(startMonth, endMonth, userId)
+
+        val eventListDTO = eventList.map { EventMainResponseDTO.from(it) }
+
+        return eventListDTO
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
@@ -1,7 +1,8 @@
 package com.dnight.calinify.event_group.dto.request
 
-import com.dnight.calinify.common.colorSets.ColorSetsEntity
+import com.dnight.calinify.common.colorSet.ColorSetEntity
 import com.dnight.calinify.event_group.entity.EventGroupEntity
+import com.dnight.calinify.event_group.entity.GroupCategoryEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Size
@@ -14,17 +15,22 @@ class EventGroupCreateRequestDTO (
     val description: String? = null,
 
     @field:Min(1)
-    val colorSetId: Int? = null,
+    val colorSetId: Int,
+
+    @field:Min(1)
+    val groupCategoryId : Int,
 ) {
     companion object {
         fun toEntity(eventGroupCreateRequestDTO: EventGroupCreateRequestDTO,
                      user: UserEntity,
-                     colorSet: ColorSetsEntity) : EventGroupEntity {
+                     colorSet: ColorSetEntity,
+                     groupCategory: GroupCategoryEntity) : EventGroupEntity {
             return EventGroupEntity(
                 groupName = eventGroupCreateRequestDTO.groupName,
                 description = eventGroupCreateRequestDTO.description,
                 user = user,
                 colorSet = colorSet,
+                groupCategory = groupCategory
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
@@ -1,6 +1,6 @@
 package com.dnight.calinify.event_group.entity
 
-import com.dnight.calinify.common.colorSets.ColorSetsEntity
+import com.dnight.calinify.common.colorSet.ColorSetEntity
 import com.dnight.calinify.config.basicEntity.BasicEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.*
@@ -18,12 +18,15 @@ class EventGroupEntity(
     @Column(nullable = true)
     var description : String? = null,
 
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     val user : UserEntity,
 
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "color_set_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    var colorSet : ColorSetsEntity
+    var colorSet : ColorSetEntity,
 
+    @JoinColumn(name = "group_category_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    var groupCategory : GroupCategoryEntity,
 ) : BasicEntity()

--- a/src/main/kotlin/com/Dnight/calinify/event_group/entity/GroupCategoryEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/entity/GroupCategoryEntity.kt
@@ -1,0 +1,14 @@
+package com.dnight.calinify.event_group.entity
+
+import jakarta.persistence.*
+
+
+@Entity
+@Table(name = "group_category")
+class GroupCategoryEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val groupCategoryId : Long? = null,
+
+    @Column(nullable = false)
+    val title : String,
+)

--- a/src/main/kotlin/com/Dnight/calinify/event_group/repository/GroupCategoryRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/repository/GroupCategoryRepository.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.event_group.repository
+
+import com.dnight.calinify.event_group.entity.GroupCategoryEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GroupCategoryRepository : JpaRepository<GroupCategoryEntity, Int>

--- a/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
@@ -1,6 +1,6 @@
 package com.dnight.calinify.event_group.service
 
-import com.dnight.calinify.common.colorSets.ColorSetsRepository
+import com.dnight.calinify.common.colorSet.ColorSetRepository
 import com.dnight.calinify.config.basicResponse.ResponseCode
 import com.dnight.calinify.config.basicResponse.ResponseOk
 import com.dnight.calinify.config.exception.ClientException
@@ -8,6 +8,7 @@ import com.dnight.calinify.event_group.dto.request.EventGroupCreateRequestDTO
 import com.dnight.calinify.event_group.dto.request.EventGroupUpdateRequestDTO
 import com.dnight.calinify.event_group.dto.response.EventGroupResponseDTO
 import com.dnight.calinify.event_group.repository.EventGroupRepository
+import com.dnight.calinify.event_group.repository.GroupCategoryRepository
 import com.dnight.calinify.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
@@ -17,7 +18,8 @@ import org.springframework.stereotype.Service
 class EventGroupService(
     private val eventGroupRepository: EventGroupRepository,
     private val userRepository: UserRepository,
-    private val colorSetsRepository: ColorSetsRepository,
+    private val colorSetRepository: ColorSetRepository,
+    private val groupCategoryRepository: GroupCategoryRepository,
 ) {
 
     fun getEventGroupById(eventGroupId : Long, userId: Long) : EventGroupResponseDTO {
@@ -34,10 +36,14 @@ class EventGroupService(
 
         val user = userRepository.findByIdOrNull(userId) ?: throw ClientException(ResponseCode.UserNotFound)
 
-        val colorSet = colorSetsRepository.findByIdOrNull(eventGroupCreateRequestDTO.colorSetId)
+        val colorSet = colorSetRepository.findByIdOrNull(eventGroupCreateRequestDTO.colorSetId)
             ?: throw ClientException(ResponseCode.NotFound, "color set Id")
 
-        val eventGroupEntity = EventGroupCreateRequestDTO.toEntity(eventGroupCreateRequestDTO, user, colorSet)
+        val groupCategoryEntity = groupCategoryRepository.findByIdOrNull(eventGroupCreateRequestDTO.groupCategoryId)
+            ?: throw ClientException(ResponseCode.NotFound, "group category Id")
+
+        val eventGroupEntity = EventGroupCreateRequestDTO.toEntity(
+            eventGroupCreateRequestDTO, user, colorSet, groupCategoryEntity)
 
         val eventGroup = eventGroupRepository.save(eventGroupEntity)
 
@@ -52,7 +58,7 @@ class EventGroupService(
 
         if (eventGroupEntity.user.userId != userId) throw ClientException(ResponseCode.NotYourResource)
 
-        val colorSet = colorSetsRepository.findByIdOrNull(eventGroupUpdateRequestDTO.colorSetId)
+        val colorSet = colorSetRepository.findByIdOrNull(eventGroupUpdateRequestDTO.colorSetId)
             ?: throw ClientException(ResponseCode.NotFound, "color set Id")
 
         eventGroupEntity.colorSet = colorSet

--- a/src/main/kotlin/com/Dnight/calinify/user/entity/AccountLinkEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/entity/AccountLinkEntity.kt
@@ -5,8 +5,13 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "account_link")
 class AccountLinkEntity(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val accountLinkId: Long = 0,
+    @Id
+    var userId: Long? = null,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    var user: UserEntity,
 
     var google : String? = null,
 

--- a/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/user/entity/UserEntity.kt
@@ -26,11 +26,14 @@ class UserEntity (
 
     val phoneNumber: String? = null,
 
-    @OneToOne
-    @JoinColumn(name = "account_link_id", nullable = true)
-    val accountLink : AccountLinkEntity? = null,
+    @OneToOne(mappedBy = "user", cascade = [(CascadeType.ALL)])
+    var accountLink : AccountLinkEntity? = null,
 
     val isActivated : Short = 1,
 
     val role: String = "COMMON"
-) : BasicEntity()
+) : BasicEntity() {
+    fun addAccountLink(accountLink: AccountLinkEntity) {
+        this.accountLink = accountLink
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: calinify
 
   datasource:
-    url: jdbc:mysql://localhost:3306/calinify?serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/${LOCAL_DATABASE_TABLE_NAME}?serverTimezone=UTC
     username: ${LOCAL_DATABASE_USERNAME}
     password: ${LOCAL_DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Result

event table(entity)를 event main 과 event detail로 변경하였으며, one to one 관계로 묶었음. 로직 수정이 추가로 필요함

또한 input type, color set 등의 common resource의 crud를 구현함. 관리자 api 보호 조치가 필요함.

## How

본래 15개 가량의 column을 가진 event 테이블을 분할하여, 월간 뷰에서 보여야 할 핵심적인 데이터만 가진 event main과 여러 메타 데이터 및 외래키를 가진 event detail로 분할함.

one to one 관계로 묶었으나, 식별관계 설정의 까다로움으로 인해 코드 품질의 수정이 필요함.

input type과 color set 등의 common resource의 기본적인 crud를 대부분 구현하였으나, 관리자만 접근할 수 있도록 api를 보호할 필요가 있음.