### PR TITLE
Feat : event main, detail 참조 관계 변경 및 user calendar 전체 조회

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/calendar/controller/CalendarController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/controller/CalendarController.kt
@@ -27,6 +27,15 @@ class CalendarController(
         return BasicResponse.ok(calendarService.getCalendarById(calendarId, userId), ResponseCode.ResponseSuccess)
     }
 
+    @GetMapping("/")
+    fun getAllCalendarByUser(@AuthenticationPrincipal userDetails: UserDetails): BasicResponse<List<CalendarResponseDTO>> {
+        val userId = userDetails.username.toLong()
+
+        val calendarList = calendarService.getAllCalendarByUserId(userId)
+
+        return BasicResponse.ok(calendarList, ResponseCode.ResponseSuccess)
+    }
+
     @PostMapping("/")
     fun createCalendar(@Valid @RequestBody createCalendarDTO: CalendarCreateDTO,
                        @AuthenticationPrincipal userDetails: UserDetails,

--- a/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface CalendarRepository : JpaRepository<CalendarEntity, Long> {
     fun findByCalendarIdAndUserUserId(id: Long, user: Long) : CalendarEntity?
+
+    fun findAllByUserUserId(user : Long) : List<CalendarEntity>
 }

--- a/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/service/CalendarService.kt
@@ -29,6 +29,15 @@ class CalendarService(
         return calendarResponse
     }
 
+    fun getAllCalendarByUserId(userId : Long) : List<CalendarResponseDTO> {
+
+        val calendarList = calendarRepository.findAllByUserUserId(userId)
+
+        val calendarListDTO = calendarList.map { calendar -> CalendarResponseDTO.from(calendar) }
+
+        return calendarListDTO
+    }
+
     @Transactional
     fun createCalendar(calendarData: CalendarCreateDTO, userId : Long): Long {
         val user = userRepository.findByIdOrNull(userId) ?: throw ClientException(ResponseCode.UserNotFound)

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -69,7 +69,7 @@ class EventCreateRequestDTO(
 
     @Schema(description = "사용자가 사용한 input 방식, 1:Form, 2:PlainText")
     @field:Min(1)
-    val inputTypeId: Int,
+    val inputTypeId: Int = 1,
 
     @field:Min(0)
     @Schema(description = "사용자가 일정을 등록하는 데에 활용한 종합 시간. 클라이언트에서 집계 후 전송")
@@ -89,15 +89,15 @@ class EventCreateRequestDTO(
             )
         }
 
-        fun toDetailEntity(eventMainEntity: EventMainEntity,
+        fun toDetailEntity(eventMain: EventMainEntity,
                            eventData : EventCreateRequestDTO,
                            eventGroup : EventGroupEntity?,
                            alarm : AlarmEntity?,
                            aiProcessingEventEntity: AiProcessingEventEntity?,
                            inputType: InputTypeEntity) : EventDetailEntity {
             return EventDetailEntity(
-                eventDetailId = eventMainEntity.eventId,
-                eventMain = eventMainEntity,
+                eventDetailId = eventMain.eventId!!,
+                eventMain = eventMain,
                 uid = EventUID.genUID(),
                 description = eventData.description,
                 location = eventData.location,

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventMainResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventMainResponseDTO.kt
@@ -12,7 +12,7 @@ class EventMainResponseDTO(
     val priority : Int,
 
     // 1순위로 event entity 자체에 값이 있을 경우, 2순위로 event group 3순위 calendar
-    val colorSetId : Int,
+    val colorSetId : Int?,
 ) {
     companion object {
         fun from(event : EventMainEntity) : EventMainResponseDTO {

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventDetailEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventDetailEntity.kt
@@ -10,12 +10,28 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "event_detail")
 class EventDetailEntity(
+    /**
+     * event detail -> event main 1:1 참조 관계
+     *
+     * 역방향으로 1:1 참조 관계를 설정할 경우, lazy loading이 제대로 동작하지 않는 문제가 있음.
+     *
+     * 일정 기간 내의 일정을 가져올 경우, 적어도 수 십 개의 조회 쿼리가 날아갈 수 있어, 현행을 유지하고자 함.
+     *
+     * main이 detail을 참고 하고자 할 때는, 자신의 PK로 조회하면 됨.
+     *
+     * 따라서 main -> detail 참조가 제대로 이루어질 수 있도록 로직 설계에 주의를 요함.
+     *
+     * @see com.dnight.calinify.event.entity.EventMainEntity
+     * @author 정인모
+     */
+    
     @Id
-    val eventDetailId : Long? = 0,
-
-    @MapsId
-    @OneToOne
-    @JoinColumn(name = "eventDetailId")
+    @Column(name = "event_detail_id")
+    val eventDetailId : Long,
+    
+    @MapsId(value = "eventDetailId")
+    @OneToOne(targetEntity = EventMainEntity::class, fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    @JoinColumn(name = "eventDetailId", nullable = false)
     var eventMain : EventMainEntity,
 
     @Column(nullable = false, unique = true, length = 255)

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
@@ -9,10 +9,11 @@ import java.time.LocalDateTime
 interface EventMainRepository : JpaRepository<EventMainEntity, Long> {
     fun findByEventIdAndCalendarUserUserId(eventId: Long, userId: Long) : EventMainEntity?
 
-    @Query("SELECT e FROM EventMainEntity e JOIN e.calendar c WHERE" +
+    @Query("SELECT e " +
+            "FROM EventMainEntity e WHERE" +
             "((e.endAt >= :startMonth AND e.endAt <= :endMonth) OR" +
             "(e.startAt >= :startMonth AND e.startAt <= :endMonth))" +
-            "AND c.user.userId = :userId AND e.isDeleted = 0")
+            "AND e.calendar.user.userId = :userId AND e.isDeleted = 0")
     fun findUserEventBetween(@Param("startMonth") startMonth : LocalDateTime,
                              @Param("endMonth") endMonth : LocalDateTime,
                              @Param("userId") userId: Long): List<EventMainEntity>

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
@@ -53,7 +53,7 @@ class EventService(
 
         if (eventMain.isDeleted == 1) throw ClientException(ResponseCode.DeletedResource)
 
-        val eventDetail = eventDetailRepository.findByIdOrNull(eventId)!!
+        val eventDetail = eventDetailRepository.findByIdOrNull(eventMain.eventId)!!
 
         return EventResponseDTO.from(eventMain, eventDetail)
     }
@@ -110,6 +110,8 @@ class EventService(
         val eventDetailEntity = EventCreateRequestDTO.toDetailEntity(
             eventMainEntity, eventCreateDTO, eventGroupEntity, alarmEntity, aiProcessingEventEntity, inputType)
 
+        eventDetailRepository.save(eventDetailEntity)
+
         // response DTO
         val eventResponseDTO = EventResponseDTO.from(eventMainEntity, eventDetailEntity)
 
@@ -130,7 +132,7 @@ class EventService(
         val eventMainEntity = eventMainRepository.findByEventIdAndCalendarUserUserId(eventUpdateDTO.eventId, userId)
             ?: throw ClientException(ResponseCode.NotFoundOrNotMatchUser, "event")
 
-        val eventDetailEntity = eventDetailRepository.findByIdOrNull(eventUpdateDTO.eventId)!!
+        val eventDetailEntity = eventDetailRepository.findByIdOrNull(eventMainEntity.eventId)!!
 
         // event group이 존재할 경우
         if (eventUpdateDTO.eventGroupId is Long) {


### PR DESCRIPTION
## Result 

1. event main, detail 참조 관계, 식별에서 비식별로 변경
2. user calendar 전체 조회

## How

event detail -> event main 1:1 비식별 참조관계로 변경함.

역방향으로 1:1 참조 관계를 설정할 경우, lazy loading이 제대로 동작하지 않는 문제가 있음.

일정 기간 내의 일정을 가져올 경우, 적어도 수 십 개의 조회 쿼리가 날아갈 수 있어, 현행을 유지하고자 함.

main이 detail을 참고 하고자 할 때는, 자신의 PK로 조회하면 됨.

따라서 main -> detail 참조가 제대로 이루어질 수 있도록 로직 설계에 주의를 요함.

유저의 calendar의 경우, jwt를 파싱해서 나온 user id에 따라, 갖고 있는 모든 calendar를 가져오는 것으로 해결.