### PR TITLE
Feat : calendar delete 로직 추가

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
@@ -9,6 +9,8 @@ import java.time.LocalDateTime
 interface EventMainRepository : JpaRepository<EventMainEntity, Long> {
     fun findByEventIdAndCalendarUserUserId(eventId: Long, userId: Long) : EventMainEntity?
 
+    fun findAllByCalendarCalendarId(calendarId: Long): List<EventMainEntity>
+
     @Query("SELECT e " +
             "FROM EventMainEntity e WHERE" +
             "((e.endAt >= :startMonth AND e.endAt <= :endMonth) OR" +


### PR DESCRIPTION
## Result

calendar의 deleted를 1로 바꾸었음에도 delete 메서드가 계속해서 먹힌 점 수정,

calendar를 삭제한 경우, 이를 참조하는 event의 delete를 1로 수정

## How

.map { it.isDeleted = 1 } . 이먹히는 것을 확인하였음.

map 함수를 자주 쓰게 될  것같음.