### PR TITLE
feat : calendar 기준 event 반환 api 생성

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/calendar/repository/CalendarRepository.kt
@@ -7,4 +7,5 @@ interface CalendarRepository : JpaRepository<CalendarEntity, Long> {
     fun findByCalendarIdAndUserUserId(id: Long, user: Long) : CalendarEntity?
 
     fun findAllByUserUserId(user : Long) : List<CalendarEntity>
+
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/controller/EventListController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/controller/EventListController.kt
@@ -2,15 +2,13 @@ package com.dnight.calinify.event.controller
 
 import com.dnight.calinify.config.basicResponse.BasicResponse
 import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
 import com.dnight.calinify.event.dto.response.EventMainResponseDTO
 import com.dnight.calinify.event.service.EventListService
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
 
 
@@ -20,7 +18,26 @@ import java.time.LocalDateTime
 class EventListController(
     private val eventListService: EventListService
 ) {
-    @GetMapping("/month")
+    @GetMapping("/all")
+    fun getAllEvent(@AuthenticationPrincipal userDetails: UserDetails): BasicResponse<List<EventMainResponseDTO>> {
+        val userId = userDetails.username.toLong()
+
+        val eventList = eventListService.getAllEvent(userId)
+
+        return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping("/{calendarId}")
+    fun getAllEventByCalendar(@PathVariable calendarId: Long,
+                              @AuthenticationPrincipal userDetails: UserDetails) : BasicResponse<List<EventMainResponseDTO>> {
+        val userId = userDetails.username.toLong()
+
+        val eventList = eventListService.getAllEventByCalendar(calendarId, userId)
+
+        return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping("/monthEvent")
     fun getMonthEventList(@RequestParam(required = true) year: Int,
                           @RequestParam(required = true) month: Int,
                           @AuthenticationPrincipal userDetails: UserDetails
@@ -31,12 +48,37 @@ class EventListController(
         return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
     }
 
-    @GetMapping("/week")
+    @GetMapping("/weekEvent")
     fun getWeekEventList(@RequestParam(required = true) date : LocalDateTime,
                          @AuthenticationPrincipal userDetails: UserDetails,
                          ): BasicResponse<List<EventMainResponseDTO>> {
         val userId = userDetails.username.toLong()
         val eventList = eventListService.getWeekEventList(date, userId)
+
+        return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping("/monthCalendar")
+    fun getMonthEventListByCalendar(@RequestParam(required = true) year: Int,
+                                    @RequestParam(required = true) month: Int,
+                                    @RequestParam(required = true) calendarId : Long,
+                                    @AuthenticationPrincipal userDetails: UserDetails,
+                                    ): BasicResponse<List<EventMainResponseDTO>> {
+        val userId = userDetails.username.toLong()
+        val eventList = eventListService.getMonthEventListByCalendar(year, month, userId, calendarId)
+
+        if (eventList.isEmpty()) throw ClientException(ResponseCode.NotFound, "calendar, month")
+
+        return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
+    }
+
+    @GetMapping("/weekCalendar")
+    fun getWeekEventListByCalendar(@RequestParam(required = true) date : LocalDateTime,
+                                   @RequestParam(required = true) calendarId : Long,
+                                   @AuthenticationPrincipal userDetails: UserDetails,
+    ): BasicResponse<List<EventMainResponseDTO>> {
+        val userId = userDetails.username.toLong()
+        val eventList = eventListService.getWeekEventListByCalendar(date, calendarId, userId)
 
         return BasicResponse.ok(eventList, ResponseCode.ResponseSuccess)
     }

--- a/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/repository/EventMainRepository.kt
@@ -19,4 +19,16 @@ interface EventMainRepository : JpaRepository<EventMainEntity, Long> {
     fun findUserEventBetween(@Param("startMonth") startMonth : LocalDateTime,
                              @Param("endMonth") endMonth : LocalDateTime,
                              @Param("userId") userId: Long): List<EventMainEntity>
+
+    @Query("SELECT e " +
+            "FROM EventMainEntity e " +
+            "WHERE e.calendar.user.userId = :userId " +
+            "AND e.calendar.calendarId = :calendarId " +
+            "AND e.isDeleted = 0 " +
+            "AND ((e.endAt >= :startMonth AND e.endAt <= :endMonth) OR " +
+            "(e.startAt >= :startMonth AND e.startAt <= :endMonth)) ")
+    fun findUserEventBetweenByCalendarCalendarId(@Param("startMonth") startMonth : LocalDateTime,
+                                                 @Param("endMonth") endMonth : LocalDateTime,
+                                                 @Param("userId") userId: Long,
+                                                 @Param("calendarId") calendarId: Long): List<EventMainEntity>
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventListService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventListService.kt
@@ -1,5 +1,8 @@
 package com.dnight.calinify.event.service
 
+import com.dnight.calinify.calendar.repository.CalendarRepository
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ClientException
 import com.dnight.calinify.event.dto.response.EventMainResponseDTO
 import com.dnight.calinify.event.entity.EventMainEntity
 import com.dnight.calinify.event.repository.EventMainRepository
@@ -11,16 +14,46 @@ import java.time.temporal.TemporalAdjusters
 
 @Service
 class EventListService(
+    private val calendarRepository: CalendarRepository,
     private val eventMainRepository: EventMainRepository,
     private val userRepository: UserRepository,
 ) {
+    fun getAllEvent(userId : Long) : List<EventMainResponseDTO> {
+        val calendarList = calendarRepository.findAllByUserUserId(userId)
+
+        val eventList : MutableList<EventMainResponseDTO> = mutableListOf()
+
+        // calendar의 삭제 여부 판별 후, event 개별 삭제 여부 판별
+        for (calendar in calendarList) {
+            if (calendar.isDeleted == 1) continue
+            eventMainRepository.findAllByCalendarCalendarId(calendar.calendarId)
+                .forEach { if(it.isDeleted == 0) eventList.add(EventMainResponseDTO.from(it)) }
+        }
+
+        return eventList
+    }
+
+    fun getAllEventByCalendar(calendarId: Long, userId: Long) : List<EventMainResponseDTO> {
+
+        // calendar의 user검증
+        val calendar = calendarRepository.findByCalendarIdAndUserUserId(id = calendarId, user = userId)
+            ?: throw ClientException(ResponseCode.NotFoundOrNotMatchUser)
+
+        if (calendar.isDeleted == 1) throw ClientException(ResponseCode.DeletedResource)
+
+        val eventList = eventMainRepository.findAllByCalendarCalendarId(calendarId).mapNotNull {
+            if (it.isDeleted == 0) EventMainResponseDTO.from(it) else null}
+
+        return eventList
+    }
+
     fun getMonthEventList(year: Int, month: Int, userId: Long) : List<EventMainResponseDTO> {
 
         val startMonth : LocalDateTime = LocalDateTime.of(year, month, 1, 0, 0)
         val endMonth : LocalDateTime = LocalDateTime.of(year, month+1, 1, 0, 0).minusSeconds(1)
 
         val eventList : List<EventMainEntity> = eventMainRepository.findUserEventBetween(startMonth, endMonth, userId)
-
+        // 위에서 userId, delete 판별
         val eventListDTO = eventList.map { EventMainResponseDTO.from(it) }
 
         return eventListDTO
@@ -31,7 +64,32 @@ class EventListService(
         val weekPair : Pair<LocalDateTime, LocalDateTime> = getWeekRange(date)
 
         val eventList : List<EventMainEntity> = eventMainRepository.findUserEventBetween(weekPair.first, weekPair.second, userId)
+        // 위에서 userId, delete 판별
+        val eventListDTO = eventList.map { EventMainResponseDTO.from(it) }
 
+        return eventListDTO
+    }
+
+    fun getMonthEventListByCalendar(year: Int, month: Int, userId: Long, calendarId: Long) : List<EventMainResponseDTO> {
+
+        val startMonth : LocalDateTime = LocalDateTime.of(year, month, 1, 0, 0)
+        val endMonth : LocalDateTime = LocalDateTime.of(year, month+1, 1, 0, 0).minusSeconds(1)
+
+        val eventList : List<EventMainEntity> =
+            eventMainRepository.findUserEventBetweenByCalendarCalendarId(startMonth, endMonth, userId, calendarId)
+        // 위에서 userId, delete 판별
+        val eventListDTO = eventList.map { EventMainResponseDTO.from(it) }
+
+        return eventListDTO
+    }
+
+    fun getWeekEventListByCalendar(date : LocalDateTime, calendarId: Long, userId: Long) : List<EventMainResponseDTO> {
+
+        val weekPair : Pair<LocalDateTime, LocalDateTime> = getWeekRange(date)
+
+        val eventList : List<EventMainEntity> =
+            eventMainRepository.findUserEventBetweenByCalendarCalendarId(weekPair.first, weekPair.second, userId, calendarId)
+        // 위에서 userId, delete 판별
         val eventListDTO = eventList.map { EventMainResponseDTO.from(it) }
 
         return eventListDTO


### PR DESCRIPTION
## Result

calendar id를 기반으로 유저의 id를 가져오는 api를 생성함.

추가적으로 is deleted 체크를 넣어, 삭제한 리소스는 반환하지 않는 것으로 수정함.

## How

jpql을 활용해 쿼리에서 delete와 userId를 체크하는 로직과, 일단 값을 가져오고 서비스에서 체크하는 로직  두 방식을 만들었음.

원활한 개발을 위해 다양한 코드를 뱉어내는 게 맞지만, 지나치게 서비스에서 많은 처리를 하게 만들 것 같아 한 번의 쿼리로 끝낼  수 있는 요청은 한번의 요청으로 끝내고자 함.