### PR TITLE
fix : exception stack trace, color set 문제 해결

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/BasicResponse.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/BasicResponse.kt
@@ -50,8 +50,14 @@ data class BasicResponse<T> (
                 return BasicResponse(ExceptionResponse(responseCode.message), responseCode)
             }
 
+            fun fail(responseCode: ResponseCode, detailMessage : DetailExceptionResponse): BasicResponse<DetailExceptionResponse> {
+                return BasicResponse(detailMessage, responseCode)
+            }
+
             /**
              * request의 값 검증이 실패한 경우, 지정된 에러 메시지와 코드 및 필드 내역을 반환한다.
+             *
+             * 또는 추가적인 지침이 필요한 에러에 대해 디테일 메시지를 더해준다.
              */
             fun <T>fail(responseCode: ResponseCode, failedValidationData: T): BasicResponse<FailedValidationResponse<T>> {
                 return BasicResponse(FailedValidationResponse(responseCode.message, failedValidationData), responseCode)

--- a/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ExceptionResponse.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/basicResponse/ExceptionResponse.kt
@@ -9,6 +9,17 @@ class ExceptionResponse(
     val message: String,
 )
 
+/**
+ * ResponseCode의 메세지에 추가적인 detail message가 필요할 때 사용
+ */
+class DetailExceptionResponse(
+    val detailMessage : String
+)
+
+/**
+ * http reqeust에서 DTO validation error 발생 시 활용
+ */
+
 class FailedValidationResponse<T>(
     val message: String,
     val detail: T,

--- a/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/Dnight/calinify/config/exception/GlobalExceptionHandler.kt
@@ -1,9 +1,6 @@
 package com.dnight.calinify.config.exception
 
-import com.dnight.calinify.config.basicResponse.BasicResponse
-import com.dnight.calinify.config.basicResponse.ExceptionResponse
-import com.dnight.calinify.config.basicResponse.FailedValidationResponse
-import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.basicResponse.*
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.core.AuthenticationException
@@ -77,12 +74,9 @@ class GlobalExceptionHandler {
      * @author 정인모
      */
     @ExceptionHandler(ClientException::class)
-    fun handleClientException(ex: ClientException): BasicResponse<ExceptionResponse> {
-        ex.detail ?:
-        return BasicResponse.fail(ex.responseCode)
-
-        ex.responseCode.message += " -> " + ex.detail
-        return BasicResponse.fail(ex.responseCode)
+    fun handleClientException(ex: ClientException): BasicResponse<DetailExceptionResponse> {
+        val detailMessage = DetailExceptionResponse(ex.responseCode.message + " -> " + (ex.detail ?: "Unknown"))
+        return BasicResponse.fail(ex.responseCode, detailMessage)
     }
 
     /**

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/request/EventCreateRequestDTO.kt
@@ -56,7 +56,7 @@ class EventCreateRequestDTO(
     val calendarId: Long,
 
     @Schema(description = "일정의 컬러셋, 생략 가능", defaultValue = "1")
-    val colorSetId : Int? = null,
+    var colorSetId : Int? = 1,
 
     @Schema(description = "일정 그룹의 ID, 생략 가능")
     val eventGroupId : Long? = null,

--- a/src/main/kotlin/com/Dnight/calinify/event/entity/EventMainEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/entity/EventMainEntity.kt
@@ -44,7 +44,7 @@ class EventMainEntity(
     var isDeleted : Int = 0,
 
     @Column(nullable = true)
-    var colorSetId : Int? = null,
+    var colorSetId : Int? = 1,
 
     @Column(nullable = true)
     var isAllday : Int = 0

--- a/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/service/EventService.kt
@@ -64,12 +64,14 @@ class EventService(
         val calendarEntity = calendarRepository.findByCalendarIdAndUserUserId(eventCreateDTO.calendarId, userId)
             ?: throw ClientException(ResponseCode.NotFoundOrNotMatchUser, "calendar")
         if (calendarEntity.isDeleted == 1) throw ClientException(ResponseCode.DeletedResource, "calendar")
+        var eventColorSetId = calendarEntity.colorSetId
 
         // get event group - eventGroupId가 있을 경우 검색 후 값 집어넣기, 아니면 null 삽입
         var eventGroupEntity : EventGroupEntity? = null
         if (eventCreateDTO.eventGroupId is Long) {
             eventGroupEntity = eventGroupRepository.findByIdOrNull(eventCreateDTO.eventGroupId)
                 ?: throw ClientException(ResponseCode.NotFound, "eventGroup")
+            eventColorSetId = eventGroupEntity.colorSetId
         }
 
         // alarm 생성 정보가 들어올 경우, 알람 생성도 진행, ID 반환받아와서 다시 검색하고 값 넣어줌.
@@ -89,6 +91,9 @@ class EventService(
             aiProcessingEventEntity = aiProcessingEventRepository.findByIdOrNull(eventCreateDTO.processedEventId)
                 ?: throw ClientException(ResponseCode.NotFound, "ai processing event")
         }
+
+        // 색상 지정
+        eventCreateDTO.colorSetId = eventColorSetId
 
         // event main entity 저장
         var eventMainEntity = EventCreateRequestDTO.toMainEntity(eventCreateDTO, calendarEntity)
@@ -150,6 +155,7 @@ class EventService(
         eventDetailEntity.status = eventUpdateDTO.status
         eventDetailEntity.transp = eventUpdateDTO.transp
         eventMainEntity.priority = eventUpdateDTO.priority
+        eventMainEntity.isAllday = eventUpdateDTO.isAllday
 
         // 선택값
         eventDetailEntity.description = eventUpdateDTO.description

--- a/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/entity/EventGroupEntity.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.event_group.entity
 
-import com.dnight.calinify.common.colorSet.ColorSetEntity
 import com.dnight.calinify.config.basicEntity.BasicEntity
 import com.dnight.calinify.user.entity.UserEntity
 import jakarta.persistence.*
@@ -22,9 +21,8 @@ class EventGroupEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     val user : UserEntity,
 
-    @JoinColumn(name = "color_set_id", nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    var colorSet : ColorSetEntity,
+    @Column(nullable = false)
+    var colorSetId : Int,
 
     @JoinColumn(name = "group_category_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## Result

1. 종종 벌어지던 500 에러의 문제는 백엔드 로직의 미흡으로 colorSetId가 지정되지 않았음.

2. 또한 exception handler 객체에서 message를 계속해서 쌓는 문제를 해결함 

## Why

1. colorSetId는 필수값이었으나, 기본값 및 null의 대처 미흡으로 NPE가 발생함.

2. Exception

```kotlin
@ControllerAdvice
class GlobalExceptionHandler {
    @ExceptionHandler(ClientException::class)
    fun handleClientException(ex: ClientException): BasicResponse<ExceptionResponse> {
        ex.detail ?:
        return BasicResponse.fail(ex.responseCode)

        ex.responseCode.message += " -> " + ex.detail  // <- 문제 발생지점
        return BasicResponse.fail(ex.responseCode)
````

repsonseCode는 Enum 클래스로, 싱글톤 객체기 때문에 에러 메시지마다 responseCode.message를 수정하며 해당 메시지에 계속 내용이 추가됨.

## How

### ColorSet

ColorSet은 필수값으로 지정되어 있으나, entity와 dto에 기본값 및 null 대처 방안이 마련되어 있지 않아 NPE가 발생함.

따라서, 가장 우선 순위가 낮은 calendar의 colorSetId로 시작해, 다음 우선순위인 eventGroup 내 colorSetId를 받고, 마지막으로 event 생성 DTO에 담긴 colorSetId를 대입하여 color set을 지정해줌.

또한 dto와 entity에 기본값을 지정함. 이를 서비스의 primary color로 설정하면 될 것 같음.

### Exception Trace Stack 문제

이를 통해 다발적이고 이유가 모호한 getEvent의 500 에러를 해결함.

response 메서드의 수정을 통해 싱글톤 객체인 responseCode를 수정하지 않고 새로운 문자열 메시지 객체를 생성해 반환하는 식으로 수정함.

```kotlin
    @ExceptionHandler(ClientException::class)
    fun handleClientException(ex: ClientException): BasicResponse<DetailExceptionResponse> {
        val detailMessage = DetailExceptionResponse(ex.responseCode.message + " -> " + (ex.detail ?: "Unknown"))
        return BasicResponse.fail(ex.responseCode, detailMessage)
```


