### PR TITLE
fix : colorSet -> colorSetId 수정

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupCreateRequestDTO.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.event_group.dto.request
 
-import com.dnight.calinify.common.colorSet.ColorSetEntity
 import com.dnight.calinify.event_group.entity.EventGroupEntity
 import com.dnight.calinify.event_group.entity.GroupCategoryEntity
 import com.dnight.calinify.user.entity.UserEntity
@@ -23,13 +22,13 @@ class EventGroupCreateRequestDTO (
     companion object {
         fun toEntity(eventGroupCreateRequestDTO: EventGroupCreateRequestDTO,
                      user: UserEntity,
-                     colorSet: ColorSetEntity,
+                     colorSetId: Int,
                      groupCategory: GroupCategoryEntity) : EventGroupEntity {
             return EventGroupEntity(
                 groupName = eventGroupCreateRequestDTO.groupName,
                 description = eventGroupCreateRequestDTO.description,
                 user = user,
-                colorSet = colorSet,
+                colorSetId = colorSetId,
                 groupCategory = groupCategory
             )
         }

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupUpdateRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/request/EventGroupUpdateRequestDTO.kt
@@ -14,5 +14,5 @@ class EventGroupUpdateRequestDTO (
     val description: String? = null,
 
     @field:Min(1)
-    val colorSetId: Int? = null,
+    val colorSetId: Int,
 )

--- a/src/main/kotlin/com/Dnight/calinify/event_group/dto/response/EventGroupResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/dto/response/EventGroupResponseDTO.kt
@@ -14,7 +14,7 @@ class EventGroupResponseDTO(
             return EventGroupResponseDTO(
                 groupName = groupEntity.groupName,
                 description = groupEntity.description,
-                colorSetId = groupEntity.colorSet.colorSetId,
+                colorSetId = groupEntity.colorSetId,
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event_group/service/EventGroupService.kt
@@ -36,14 +36,11 @@ class EventGroupService(
 
         val user = userRepository.findByIdOrNull(userId) ?: throw ClientException(ResponseCode.UserNotFound)
 
-        val colorSet = colorSetRepository.findByIdOrNull(eventGroupCreateRequestDTO.colorSetId)
-            ?: throw ClientException(ResponseCode.NotFound, "color set Id")
-
         val groupCategoryEntity = groupCategoryRepository.findByIdOrNull(eventGroupCreateRequestDTO.groupCategoryId)
             ?: throw ClientException(ResponseCode.NotFound, "group category Id")
 
         val eventGroupEntity = EventGroupCreateRequestDTO.toEntity(
-            eventGroupCreateRequestDTO, user, colorSet, groupCategoryEntity)
+            eventGroupCreateRequestDTO, user, eventGroupCreateRequestDTO.colorSetId, groupCategoryEntity)
 
         val eventGroup = eventGroupRepository.save(eventGroupEntity)
 
@@ -58,10 +55,7 @@ class EventGroupService(
 
         if (eventGroupEntity.user.userId != userId) throw ClientException(ResponseCode.NotYourResource)
 
-        val colorSet = colorSetRepository.findByIdOrNull(eventGroupUpdateRequestDTO.colorSetId)
-            ?: throw ClientException(ResponseCode.NotFound, "color set Id")
-
-        eventGroupEntity.colorSet = colorSet
+        eventGroupEntity.colorSetId = eventGroupUpdateRequestDTO.colorSetId
         eventGroupEntity.groupName = eventGroupUpdateRequestDTO.groupName
         eventGroupEntity.description = eventGroupUpdateRequestDTO.description
 


### PR DESCRIPTION
## Result

eventGroup의 colorSet 항목들을 colorSetId로 수정함

## Why

colorSet을 위해 쿼리를 날리는 것보다, id만 저장하는 것이 합리적이라는 판단.