### PR TITLE
feat : 이미지를 활용한 일정 등록 기능 생성

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/controller/EventProcessingController.kt
@@ -1,5 +1,6 @@
 package com.dnight.calinify.ai_process.controller
 
+import com.dnight.calinify.ai_process.dto.request.ImageProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.response.ProcessedEventResponseDTO
 import com.dnight.calinify.ai_process.service.EventProcessingService
@@ -7,10 +8,8 @@ import com.dnight.calinify.config.basicResponse.BasicResponse
 import com.dnight.calinify.config.basicResponse.ResponseCode
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/eventProcessing")
@@ -23,6 +22,21 @@ class EventProcessingController(
                             ): BasicResponse<ProcessedEventResponseDTO> {
         val userId = userDetails.username.toLong()
         val processedEventResponse = eventProcessingService.createPlainTextEvent(plainTextProcessingRequestDTO, userId)
+
+        return BasicResponse.ok(processedEventResponse, ResponseCode.RequestSuccess)
+    }
+
+    @PostMapping("/imageProcessing", consumes = ["multipart/form-data"])
+    /*
+    이미지를 통해 일정 데이터를 만드는 기능
+     */
+    fun createImageEvent(@RequestParam("file") file: MultipartFile,
+                         @RequestParam("promptId") promptId: Int,
+                         @RequestParam("inputType") inputType: Int,
+                         @AuthenticationPrincipal userDetails: UserDetails,) : BasicResponse<ProcessedEventResponseDTO> {
+        val userId = userDetails.username.toLong()
+        val imageProcessingRequestDTO = ImageProcessingRequestDTO(promptId, inputType)
+        val processedEventResponse = eventProcessingService.createImageEvent(imageProcessingRequestDTO, file, userId)
 
         return BasicResponse.ok(processedEventResponse, ResponseCode.RequestSuccess)
     }

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/ImageProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/request/ImageProcessingRequestDTO.kt
@@ -1,0 +1,6 @@
+package com.dnight.calinify.ai_process.dto.request
+
+class ImageProcessingRequestDTO(
+    val promptId : Int,
+    val inputType : Int,
+)

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/response/ProcessedEventResponseDTO.kt
@@ -1,6 +1,6 @@
 package com.dnight.calinify.ai_process.dto.response
 
-import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import java.time.LocalDateTime
 
 class ProcessedEventResponseDTO(
@@ -16,7 +16,7 @@ class ProcessedEventResponseDTO(
     val repeatRule : String?,
 ) {
     companion object {
-        fun from(processedEventId: Long, processedResponseBody : AiPlainTextProcessedResponseDTO) : ProcessedEventResponseDTO {
+        fun from(processedEventId: Long, processedResponseBody : AiResponseDTO) : ProcessedEventResponseDTO {
             return ProcessedEventResponseDTO(
                 processedEventId = processedEventId,
                 summary = processedResponseBody.summary,

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiImageProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiImageProcessingRequestDTO.kt
@@ -1,0 +1,17 @@
+package com.dnight.calinify.ai_process.dto.to_ai.request
+
+import com.dnight.calinify.ai_process.dto.request.ImageProcessingRequestDTO
+
+class AiImageProcessingRequestDTO(
+    override val promptId: Int,
+    val inputType : Int,
+): AiRequestDTO() {
+    companion object {
+        fun toDTO(imageProcessingRequestDTO: ImageProcessingRequestDTO) : AiImageProcessingRequestDTO {
+            return AiImageProcessingRequestDTO(
+                promptId = imageProcessingRequestDTO.promptId,
+                inputType = imageProcessingRequestDTO.inputType
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/request/AiPlainTextProcessingRequestDTO.kt
@@ -7,10 +7,10 @@ class AiPlainTextProcessingRequestDTO(
     val plainText : String
 ) : AiRequestDTO() {
     companion object {
-        fun toEntity(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : AiPlainTextProcessingRequestDTO {
+        fun toDTO(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO) : AiPlainTextProcessingRequestDTO {
             return AiPlainTextProcessingRequestDTO(
-                plainTextProcessingRequestDTO.promptId,
-                plainTextProcessingRequestDTO.originText
+                promptId = plainTextProcessingRequestDTO.promptId,
+                plainText = plainTextProcessingRequestDTO.originText
             )
         }
     }

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiImageProcessedResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiImageProcessedResponseDTO.kt
@@ -1,0 +1,50 @@
+package com.dnight.calinify.ai_process.dto.to_ai.response
+
+import com.dnight.calinify.ai_process.dto.request.ImageProcessingRequestDTO
+import com.dnight.calinify.ai_process.entity.AiProcessingEventEntity
+import com.dnight.calinify.ai_process.entity.AiProcessingStatisticsEntity
+import com.dnight.calinify.user.entity.UserEntity
+import java.time.LocalDateTime
+
+class AiImageProcessedResponseDTO(
+    summary: String,
+    start: LocalDateTime?,
+    end: LocalDateTime?,
+    responseTime: Float,
+    usedToken: Int,
+    location: String?,
+    description: String?,
+    priority: Short? = 5,
+    repeatRule: String?
+    ) : AiResponseDTO(summary, start, end, responseTime, usedToken, location, description, priority, repeatRule)
+{
+    companion object {
+        fun toStatisticsEntity(userEntity : UserEntity,
+                               aiImageProcessedResponseDTO: AiImageProcessedResponseDTO,
+                               inputData: ImageProcessingRequestDTO
+        ): AiProcessingStatisticsEntity {
+            return AiProcessingStatisticsEntity(
+                user = userEntity,
+                inputOriginText = "image",
+                promptId = inputData.promptId,
+                inputTypeId = inputData.inputType,
+                responseTime = aiImageProcessedResponseDTO.responseTime,
+                usedToken = aiImageProcessedResponseDTO.usedToken,
+            )
+        }
+
+        fun toEventEntity(eventProcessedStatisticsId : Long,
+                          aiImageProcessedResponseDTO: AiImageProcessedResponseDTO,
+        ) : AiProcessingEventEntity {
+            return AiProcessingEventEntity(
+                aiProcessingEventId = eventProcessedStatisticsId,
+                summary = aiImageProcessedResponseDTO.summary,
+                startAt = aiImageProcessedResponseDTO.start!!,
+                endAt = aiImageProcessedResponseDTO.end!!,
+                description = aiImageProcessedResponseDTO.description,
+                location = aiImageProcessedResponseDTO.location,
+                repeatRule = aiImageProcessedResponseDTO.repeatRule,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiPlainTextProcessedResponseDTO.kt
@@ -7,17 +7,17 @@ import com.dnight.calinify.user.entity.UserEntity
 import java.time.LocalDateTime
 
 class AiPlainTextProcessedResponseDTO(
-    val summary : String,
-    val start : LocalDateTime?,
-    val end : LocalDateTime?,
-    val responseTime : Float,
-    val usedToken : Int,
-    val location : String?,
-    val description : String?,
-    val priority : Short? = 5,
-    val repeatRule : String?,
-) : AiResponseDTO() {
-
+    summary: String,
+    start: LocalDateTime?,
+    end: LocalDateTime?,
+    responseTime: Float,
+    usedToken: Int,
+    location: String?,
+    description: String?,
+    priority: Short? = 5,
+    repeatRule: String?
+) : AiResponseDTO(summary, start, end, responseTime, usedToken, location, description, priority, repeatRule)
+{
     companion object {
         fun toStatisticsEntity(userEntity : UserEntity,
                      aiPlainTextProcessedResponseDTO: AiPlainTextProcessedResponseDTO,

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/dto/to_ai/response/AiResponseDTO.kt
@@ -1,3 +1,15 @@
 package com.dnight.calinify.ai_process.dto.to_ai.response
 
-open class AiResponseDTO
+import java.time.LocalDateTime
+
+open class AiResponseDTO(
+    val summary : String,
+    val start : LocalDateTime?,
+    val end : LocalDateTime?,
+    val responseTime : Float,
+    val usedToken : Int,
+    val location : String?,
+    val description : String?,
+    val priority : Short? = 5,
+    val repeatRule : String?,
+)

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/module/ImageRequest.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/module/ImageRequest.kt
@@ -1,0 +1,55 @@
+package com.dnight.calinify.ai_process.module
+
+import com.dnight.calinify.ai_process.dto.to_ai.request.AiImageProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import com.dnight.calinify.config.exception.ServerSideException
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import reactor.core.publisher.Mono
+import java.net.ConnectException
+import kotlin.reflect.KClass
+
+@Component
+class ImageRequest(
+    aiRequestBuilder: WebClient.Builder
+) {
+    val aiRequestClient = aiRequestBuilder.build()
+
+    fun <T : AiResponseDTO> aiRequest(requestDTO : AiImageProcessingRequestDTO, file : MultipartFile,responseCls : KClass<T>) : ResponseEntity<T>? {
+
+        val body = LinkedMultiValueMap<String, Any>().apply {
+            add("promptId", requestDTO.promptId.toString())
+            add("image", object : ByteArrayResource(file.bytes) {
+                override fun getFilename() = file.originalFilename
+            })
+        }
+        return aiRequestClient.post()
+            .uri("/api/v1/imageProcessing")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .bodyValue(body)
+            .retrieve()
+            .toEntity(responseCls.java)
+            .onErrorResume { ex ->
+                when (ex) {
+                    is WebClientRequestException -> {
+                        Mono.error(ServerSideException(ResponseCode.AiRequestFail))
+                    }
+                    is ConnectException -> {
+                        Mono.error(ServerSideException(ResponseCode.AiRequestFail))
+                    }
+                    else -> {
+                        Mono.error(RuntimeException("알 수 없는 오류 발생: ${ex.message}"))
+                    }
+                }
+            }
+            .block()
+}
+
+}

--- a/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
+++ b/src/main/kotlin/com/Dnight/calinify/ai_process/service/EventProcessingService.kt
@@ -1,9 +1,13 @@
 package com.dnight.calinify.ai_process.service
 
+import com.dnight.calinify.ai_process.dto.request.ImageProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.request.PlainTextProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.response.ProcessedEventResponseDTO
+import com.dnight.calinify.ai_process.dto.to_ai.request.AiImageProcessingRequestDTO
 import com.dnight.calinify.ai_process.dto.to_ai.request.AiPlainTextProcessingRequestDTO
+import com.dnight.calinify.ai_process.dto.to_ai.response.AiImageProcessedResponseDTO
 import com.dnight.calinify.ai_process.dto.to_ai.response.AiPlainTextProcessedResponseDTO
+import com.dnight.calinify.ai_process.module.ImageRequest
 import com.dnight.calinify.ai_process.module.PlainTextRequest
 import com.dnight.calinify.ai_process.repository.AiProcessingEventRepository
 import com.dnight.calinify.ai_process.repository.AiProcessingStatisticsRepository
@@ -16,20 +20,22 @@ import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 class EventProcessingService(
     private val aiProcessingEventRepository: AiProcessingEventRepository,
     private val aiProcessingStatisticsRepository: AiProcessingStatisticsRepository,
     private val userRepository: UserRepository,
-    private val plainTextRequest: PlainTextRequest
+    private val plainTextRequest: PlainTextRequest,
+    private val imageRequest: ImageRequest,
 ) {
     @Transactional(dontRollbackOn = [DontRollbackException::class])
     fun createPlainTextEvent(plainTextProcessingRequestDTO: PlainTextProcessingRequestDTO,
                              userId : Long) : ProcessedEventResponseDTO{
 
         // DTO로부터 ai server에 전달할 내용을 정제
-        val aiPlainTextProcessingRequestDTO = AiPlainTextProcessingRequestDTO.toEntity(plainTextProcessingRequestDTO)
+        val aiPlainTextProcessingRequestDTO = AiPlainTextProcessingRequestDTO.toDTO(plainTextProcessingRequestDTO)
 
         // ai server request
         val aiPlainTextProcessedResponseDTO = plainTextRequest.aiRequest(aiPlainTextProcessingRequestDTO, AiPlainTextProcessedResponseDTO::class)
@@ -64,5 +70,44 @@ class EventProcessingService(
             eventProcessingId, processedResponseBody)
 
         return processedEventResponseDTO
+    }
+
+    @Transactional(dontRollbackOn = [DontRollbackException::class])
+    fun createImageEvent(imageProcessingRequestDTO: ImageProcessingRequestDTO, file: MultipartFile, userId : Long) : ProcessedEventResponseDTO{
+        val aiImageProcessingRequestDTO = AiImageProcessingRequestDTO.toDTO(imageProcessingRequestDTO)
+
+        val imageProcessedResponseDTO = imageRequest.aiRequest(aiImageProcessingRequestDTO, file, AiImageProcessedResponseDTO::class)
+            ?: throw ServerSideException(ResponseCode.AiRequestFail)
+
+        // 응답으로부터 body 추출
+        val processedResponseBody = imageProcessedResponseDTO.body!!
+
+        // User 조회
+        val userEntity = userRepository.findByIdOrNull(userId) ?: throw ClientException(ResponseCode.UserNotFound)
+
+        // 통계 객체 생성
+        val eventProcessedStatisticsEntity = AiImageProcessedResponseDTO.toStatisticsEntity(userEntity, processedResponseBody, imageProcessingRequestDTO)
+
+        // 일정 정보 파악 실패 시 예외 발생, 실패 경우 저장을 위해 트랜잭션 롤백 X
+        if (imageProcessedResponseDTO.statusCode.isSameCodeAs(HttpStatus.ACCEPTED)) {
+            eventProcessedStatisticsEntity.isSuccess = 0
+            aiProcessingStatisticsRepository.save(eventProcessedStatisticsEntity)
+            throw DontRollbackException(ResponseCode.EventDataNotCaptured)
+        }
+
+        // 통계 정보 저장 및 ID 할당
+        val eventStatisticsEntity = aiProcessingStatisticsRepository.save(eventProcessedStatisticsEntity)
+        val eventProcessingId : Long = eventStatisticsEntity.aiProcessingStatisticsId!!
+
+        // 성공했을 시, processing event 삽입 (실제 유저 일정이 아닌, 통계용 데이터)
+        val processingEventEntity = AiImageProcessedResponseDTO.toEventEntity(eventProcessingId, processedResponseBody)
+        aiProcessingEventRepository.save(processingEventEntity)
+
+        // 프로세싱 결과에 event id, statistics를 삽입하여 반환
+        val processedEventResponseDTO = ProcessedEventResponseDTO.from(
+            eventProcessingId, processedResponseBody)
+
+        return processedEventResponseDTO
+
     }
 }

--- a/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
+++ b/src/main/kotlin/com/Dnight/calinify/event/dto/response/EventResponseDTO.kt
@@ -1,6 +1,5 @@
 package com.dnight.calinify.event.dto.response
 
-import com.dnight.calinify.ai_process.dto.to_ai.response.AiResponseDTO
 import com.dnight.calinify.alarm.dto.response.AlarmResponseDTO
 import com.dnight.calinify.event.entity.EventDetailEntity
 import com.dnight.calinify.event.entity.EventMainEntity
@@ -24,7 +23,7 @@ class EventResponseDTO(
     val eventGroup : EventGroupResponseDTO? = null,
     val alarm : AlarmResponseDTO? = null,
     val isAllday : Int = 0
-): AiResponseDTO() {
+){
     companion object {
         fun from(eventMain : EventMainEntity,
                  eventDetail: EventDetailEntity,) : EventResponseDTO {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,4 +33,4 @@ springdoc:
 
 connect-server:
   ai-server:
-    base-url: ${AI_SERVER_URL}
+    base-url: "http://localhost:5050/"


### PR DESCRIPTION
## Result

이미지를 통한 일정 생성 기능 구현

Json이 아닌, Multi-part로 데이터를 입력해줘야 함.

## How

일정 생성 부분은 FastAPI에서 진행 됨. 다른 통계 처리 및 데이터 저장은 Spring서버에서 다른 방식들과 거의 똑같은 로직으로 진행 됨.

gpt-4o 모델을 활용함.