### PR TITLE
feat : health check 구현 및 배포환경 docs 삭제

### DIFF
--- a/src/main/kotlin/com/Dnight/calinify/HealthCheck.kt
+++ b/src/main/kotlin/com/Dnight/calinify/HealthCheck.kt
@@ -1,0 +1,23 @@
+package com.dnight.calinify
+
+import com.dnight.calinify.config.basicResponse.BasicResponse
+import com.dnight.calinify.config.basicResponse.ResponseCode
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/")
+class HealthCheck {
+
+    @GetMapping("")
+    fun healthCheck() : BasicResponse<Map<String, String>> {
+        val healthCheckResponse : Map<String, String> = mutableMapOf<String, String> (
+            "Calinify" to "Hello World",
+            "HealthCheck" to "Ok",
+            "ServerTime" to LocalDateTime.now().toString(),
+            )
+        return BasicResponse(healthCheckResponse, ResponseCode.ResponseSuccess)
+    }
+}

--- a/src/main/kotlin/com/Dnight/calinify/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/Dnight/calinify/auth/security/SecurityConfig.kt
@@ -42,6 +42,8 @@ class SecurityConfig(
                 authorize("/swagger-ui/**", permitAll)
                 authorize("/v3/api-docs/**", permitAll)
                 authorize("/api/v1/auth/**", permitAll)
+                authorize("/health-check", permitAll)
+                authorize("/", permitAll)
                 authorize(anyRequest, authenticated)
             }
             sessionManagement {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,13 +18,6 @@ spring:
 jwt:
   secret: ${JWT_SECRET_KEY}
 
-springdoc:
-
-  api-docs:
-    path: /v3/api-docs
-  swagger-ui:
-    path: /swagger-ui.html
-
 connect-server:
   ai-server:
     base-url: ${AI_SERVER_URL}


### PR DESCRIPTION
## Result

1. 단순히 api 서버 주소 지정 없이 접근할 때, 헬스 체크를 진행해주는 api 생성
2. 배포 환경에서 swagger-ui에 접근하지 못하도록 만듦